### PR TITLE
JAVA-1720: add getList method to the Document class

### DIFF
--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -270,6 +270,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @param <T>   the type of the class
      * @return the list value of the given key, or null if the instance does not contain this key.
      * @throws ClassCastException if the elements in the list value of the given key is not of type T or the value is not a list
+     * @since 3.10
      */
     public <T> List<T> getList(final Object key, final Class<T> clazz) {
         notNull("clazz", clazz);
@@ -286,7 +287,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @param <T>   the type of the class
      * @return the list value of the given key, or the default list value if the instance does not contain this key.
      * @throws ClassCastException if the value of the given key is not of type T
-     * @since 3.5
+     * @since 3.10
      */
     public <T> List<T> getList(final Object key, final Class<T> clazz, final List<T> defaultValue) {
         notNull("defaultValue", defaultValue);
@@ -294,15 +295,9 @@ public class Document implements Map<String, Object>, Serializable, Bson {
         return constructValuesList(key, clazz, defaultValue);
     }
 
-    /**
-     * Construct the list of values for the specified key, or return the default value if the value is null.
-     * @param key    the key
-     * @param clazz  the non-null class to cast the list value to
-     * @param defaultValue  what to return if value is null
-     * @param <T>    the type of the class
-     * @return the list value of the given key, or the default list value if the instance does not contain the key.
-     * @throws ClassCastException if the value of the given type is not of type T or value is not a list
-     */
+
+    // Construct the list of values for the specified key, or return the default value if the value is null.
+    // A ClassCastException will be thrown if an element in the list is not of type T.
     @SuppressWarnings("unchecked")
     private <T> List<T> constructValuesList(final Object key, final Class<T> clazz, final List<T> defaultValue) {
         List<?> value = get(key, List.class);
@@ -311,7 +306,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
         }
 
         for (Object item : value) {
-            if (!clazz.isInstance(item)) {
+            if (!clazz.isAssignableFrom(item.getClass())) {
                 throw new ClassCastException(format("List element cannot be cast to %s", clazz.getName()));
             }
         }

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -289,7 +289,6 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @throws ClassCastException if the value of the given key is not of type T
      * @since 3.5
      */
-    @SuppressWarnings("unchecked")
     public <T> List<T> getList(final Object key, final Class<T> clazz, final List<T> defaultValue) {
         notNull("defaultValue", defaultValue);
         notNull("clazz", clazz);

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -30,9 +30,11 @@ import org.bson.types.ObjectId;
 
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -257,6 +259,28 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      */
     public Date getDate(final Object key) {
         return (Date) get(key);
+    }
+
+    /**
+     * Gets the list value of the given key, casting the list elements to the given {@code Class<T>}.  This is useful to avoid having
+     * casts in client code, though the effect is the same.
+     *
+     * @param key   the key
+     * @param clazz the non-null class to cast the list value to
+     * @param <T>   the type of the class
+     * @return the list value of the given key, or null if the instance does not contain this key.
+     * @throws ClassCastException if the list value of the given key is not of type T
+     */
+    public <T> List<T> getList(final Object key, final Class<T> clazz) {
+        notNull("clazz", clazz);
+        List<T> list = new ArrayList<T>();
+        Object value = documentAsMap.get(key);
+        if (value instanceof List) {
+            for (T item : (List<T>) value) {
+                list.add(item);
+            }
+        }
+        return list;
     }
 
     /**

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -152,6 +152,7 @@ public class DocumentTest {
         // when the value is not a list, throw exception
         try {
             List<Integer> notAList = d.getList("x", Integer.class);
+            fail("ClassCastException not thrown from getList");
         } catch (ClassCastException e) {
             assertThat(e.getMessage(), is("Value for key \"x\" is not a list."));
         }

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -37,11 +37,8 @@ import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -109,53 +106,6 @@ public class DocumentTest {
         assertEquals(2, x2);
         assertEquals(Arrays.asList("three", "four"), y2);
         assertEquals("bar", z2);
-    }
-
-    @Test
-    public void shouldGetListFromDocument() {
-        // given
-        Document d = new Document("x", 1)
-                .append("y", Arrays.asList("two", "three"))
-                .append("z", Arrays.asList(new Document("a", 1), new Document("b", 2)))
-                .append("w", new Document("a", Arrays.asList("One", "Two")))
-                .append("q", "notAList");
-
-        // when the value is a list
-        String three = d.getList("y", String.class).get(1);
-        int b = d.getList("z", Document.class).get(1).getInteger("b");
-        String two = d.get("w", Document.class).getList("a", String.class).get(1);
-
-        // extract the value from the list
-        assertEquals("three", three);
-        assertEquals(2, b);
-        assertEquals("Two", two);
-
-        // when the key is not found
-        List<String> nullValue = d.getList("yy", String.class);
-
-        // then it returns null
-        assertNull(nullValue);
-
-        // when the key is not found
-        List<String> defaultListValue = Arrays.asList("zero", "one");
-        List<String> listValue = d.getList("yy", String.class, defaultListValue);
-
-        // then it returns the default value
-        assertEquals(defaultListValue, listValue);
-    }
-
-    @Test
-    public void shouldThrowExceptionIfValueIsNotAList() {
-        // given
-        Document d = new Document("x", 1);
-
-        // when the value is not a list, throw exception
-        try {
-            List<Integer> notAList = d.getList("x", Integer.class);
-            fail("ClassCastException not thrown from getList");
-        } catch (ClassCastException e) {
-            assertThat(e.getMessage(), is("Value for key \"x\" is not a list."));
-        }
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -37,8 +37,11 @@ import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -106,6 +109,52 @@ public class DocumentTest {
         assertEquals(2, x2);
         assertEquals(Arrays.asList("three", "four"), y2);
         assertEquals("bar", z2);
+    }
+
+    @Test
+    public void shouldGetListFromDocument() {
+        // given
+        Document d = new Document("x", 1)
+                .append("y", Arrays.asList("two", "three"))
+                .append("z", Arrays.asList(new Document("a", 1), new Document("b", 2)))
+                .append("w", new Document("a", Arrays.asList("One", "Two")))
+                .append("q", "notAList");
+
+        // when the value is a list
+        String three = d.getList("y", String.class).get(1);
+        int b = d.getList("z", Document.class).get(1).getInteger("b");
+        String two = d.get("w", Document.class).getList("a", String.class).get(1);
+
+        // extract the value from the list
+        assertEquals("three", three);
+        assertEquals(2, b);
+        assertEquals("Two", two);
+
+        // when the key is not found
+        List<String> nullValue = d.getList("yy", String.class);
+
+        // then it returns null
+        assertNull(nullValue);
+
+        // when the key is not found
+        List<String> defaultListValue = Arrays.asList("zero", "one");
+        List<String> listValue = d.getList("yy", String.class, defaultListValue);
+
+        // then it returns the default value
+        assertEquals(defaultListValue, listValue);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfValueIsNotAList() {
+        // given
+        Document d = new Document("x", 1);
+
+        // when the value is not a list, throw exception
+        try {
+            List<Integer> notAList = d.getList("x", Integer.class);
+        } catch (ClassCastException e) {
+            assertThat(e.getMessage(), is("Value for key \"x\" is not a list."));
+        }
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -65,6 +65,63 @@ class DocumentSpecification extends Specification {
         doc.get('noVal', objectId) == objectId
     }
 
+    def 'should return a list with elements of the specified class'() {
+        when:
+        Document doc = Document.parse("{x: 1, y: ['two', 'three'], z: [{a: 'one'}, {b:2}], w: {a: ['One', 'Two']}}")
+        List<String> defaultList = Arrays.asList('a', 'b', 'c')
+
+        then:
+        doc.getList('y', String).get(0) == 'two'
+        doc.getList('y', String).get(1) == 'three'
+        doc.getList('z', Document).get(0).getString('a') == 'one'
+        doc.getList('z', Document).get(1).getInteger('b') == 2
+        doc.get('w', Document).getList('a', String).get(0) == 'One'
+        doc.get('w', Document).getList('a', String).get(1) == 'Two'
+        doc.getList('invalidKey', Document, defaultList).get(0) == 'a'
+        doc.getList('invalidKey', Document, defaultList).get(1) == 'b'
+        doc.getList('invalidKey', Document, defaultList).get(2) == 'c'
+    }
+
+    def 'should return null list when key is not found'() {
+        when:
+        Document doc = Document.parse('{x: 1}')
+
+        then:
+        doc.getList('a', String) == null
+    }
+
+    def 'should return specified default value when key is not found'() {
+        when:
+        Document doc = Document.parse('{x: 1}')
+        List<String> defaultList = Arrays.asList('a', 'b', 'c')
+
+        then:
+        doc.getList('a', String, defaultList) == defaultList
+    }
+
+    def 'should throw an exception when the list elements are not objects of the specified class'() {
+        given:
+        Document doc = Document.parse('{x: 1, y: [{a: 1}, {b: 2}], z: [1, 2]}')
+
+        when:
+        doc.getList('x', String)
+
+        then:
+        thrown(ClassCastException)
+
+        when:
+        doc.getList('y', String)
+
+        then:
+        thrown(ClassCastException)
+
+        when:
+        doc.getList('z', String)
+
+        then:
+        thrown(ClassCastException)
+    }
+
     def 'should parse a valid JSON string to a Document'() {
         when:
         Document document = Document.parse("{ 'int' : 1, 'string' : 'abc' }");

--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -68,6 +68,7 @@ class DocumentSpecification extends Specification {
     def 'should return a list with elements of the specified class'() {
         when:
         Document doc = Document.parse("{x: 1, y: ['two', 'three'], z: [{a: 'one'}, {b:2}], w: {a: ['One', 'Two']}}")
+                .append('numberList', Arrays.asList(10, 20.5d, 30L))
         List<String> defaultList = Arrays.asList('a', 'b', 'c')
 
         then:
@@ -80,6 +81,9 @@ class DocumentSpecification extends Specification {
         doc.getList('invalidKey', Document, defaultList).get(0) == 'a'
         doc.getList('invalidKey', Document, defaultList).get(1) == 'b'
         doc.getList('invalidKey', Document, defaultList).get(2) == 'c'
+        doc.getList('numberList', Number).get(0) == 10
+        doc.getList('numberList', Number).get(1) == 20.5d
+        doc.getList('numberList', Number).get(2) == 30L
     }
 
     def 'should return null list when key is not found'() {


### PR DESCRIPTION
Added two `getList` methods, one with a default value of the key is not found and one without. Tests have been added to test the new methods.