### PR TITLE
JAVA-2532: added getEmbedded methods

### DIFF
--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -222,9 +222,6 @@ public class Document implements Map<String, Object>, Serializable, Bson {
             value = ((Document) value).get(key);
             if (!(value instanceof Document)) {
                 if (value == null) {
-                    if (keyIterator.hasNext() && !isEmpty()) {
-                        throw new ClassCastException(format("The key %s is not a Document", key));
-                    }
                     return defaultValue;
                 } else if (keyIterator.hasNext()) {
                     throw new ClassCastException(format("At key %s, the value is not a Document (%s)",

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -222,7 +222,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
             value = ((Document) value).get(key);
             if (!(value instanceof Document)) {
                 if (value == null) {
-                    if (keyIterator.hasNext()) {
+                    if (keyIterator.hasNext() && !isEmpty()) {
                         throw new ClassCastException(format("The key %s is not a Document", key));
                     }
                     return defaultValue;

--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -72,7 +72,12 @@ class DocumentSpecification extends Specification {
         then:
         document.getEmbedded(List.of('notAKey'), String) == null
         document.getEmbedded(List.of('b', 'y', 'notAKey'), String) == null
+        document.getEmbedded(List.of('b', 'b', 'm'), String) == null
         Document.parse('{}').getEmbedded(List.of('a', 'b'), Integer) == null
+        Document.parse('{b: 1}').getEmbedded(['a'], Integer) == null
+        Document.parse('{b: 1}').getEmbedded(['a', 'b'], Integer) == null
+        Document.parse('{a: {c: 1}}').getEmbedded(['a', 'b'], Integer) == null
+        Document.parse('{a: {c: 1}}').getEmbedded(['a', 'b', 'c'], Integer) == null
     }
 
     def 'should return embedded value'() {
@@ -126,6 +131,12 @@ class DocumentSpecification extends Specification {
         thrown(IllegalStateException)
 
         when:
+        document.getEmbedded(['a', 'b'], Integer)
+
+        then:
+        thrown(ClassCastException)
+
+        when:
         document.getEmbedded(List.of('b', 'y', 'm'), Integer)
 
         then:
@@ -133,12 +144,6 @@ class DocumentSpecification extends Specification {
 
         when:
         document.getEmbedded(List.of('b', 'x'), Document)
-
-        then:
-        thrown(ClassCastException)
-
-        when:
-        document.getEmbedded(List.of('b', 'b', 'm'), String)
 
         then:
         thrown(ClassCastException)

--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -72,6 +72,7 @@ class DocumentSpecification extends Specification {
         then:
         document.getEmbedded(List.of('notAKey'), String) == null
         document.getEmbedded(List.of('b', 'y', 'notAKey'), String) == null
+        Document.parse('{}').getEmbedded(List.of('a', 'b'), Integer) == null
     }
 
     def 'should return embedded value'() {


### PR DESCRIPTION
A `getEmbedded` method has been added for each of the corresponding `get` methods in the `Document` class. If the key list passed to the `getEmbedded` method is `null` or empty, the `getEmbedded` methods return `null` or the default value if specified. If an embedded key in the key list does not map to a `Document` value and the key is not the last element in the key list, `null` is returned. 

`./gradlew check` runs successfully.