### PR TITLE
JAVA-2532: update DocumentSpecification unit tests

### DIFF
--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -131,10 +131,10 @@ class DocumentSpecification extends Specification {
         Document document = Document.parse("{a: 1, b: {x: [2, 3, 4], y: {m: 'one', len: 3}}, 'a.b': 'two'}")
 
         then:
-        document.getEmbedded(List.of('notAKey'), String) == null
-        document.getEmbedded(List.of('b', 'y', 'notAKey'), String) == null
-        document.getEmbedded(List.of('b', 'b', 'm'), String) == null
-        Document.parse('{}').getEmbedded(List.of('a', 'b'), Integer) == null
+        document.getEmbedded(Arrays.asList('notAKey'), String) == null
+        document.getEmbedded(Arrays.asList('b', 'y', 'notAKey'), String) == null
+        document.getEmbedded(Arrays.asList('b', 'b', 'm'), String) == null
+        Document.parse('{}').getEmbedded(Arrays.asList('a', 'b'), Integer) == null
         Document.parse('{b: 1}').getEmbedded(['a'], Integer) == null
         Document.parse('{b: 1}').getEmbedded(['a', 'b'], Integer) == null
         Document.parse('{a: {c: 1}}').getEmbedded(['a', 'b'], Integer) == null
@@ -155,15 +155,15 @@ class DocumentSpecification extends Specification {
                 .append('n', new Document('date', date))
 
         then:
-        document.getEmbedded(List.of('a'), Integer) == 1
-        document.getEmbedded(List.of('b', 'x'), List).get(0) == 2
-        document.getEmbedded(List.of('b', 'x'), List).get(1) == 3
-        document.getEmbedded(List.of('b', 'x'), List).get(2) == 4
-        document.getEmbedded(List.of('b', 'y', 'm'), String) == 'one'
-        document.getEmbedded(List.of('b', 'y', 'len'), Integer) == 3
-        document.getEmbedded(List.of('a.b'), String) == 'two'
-        document.getEmbedded(List.of('b', 'y'), Document).getString('m') == 'one'
-        document.getEmbedded(List.of('b', 'y'), Document).getInteger('len') == 3
+        document.getEmbedded(Arrays.asList('a'), Integer) == 1
+        document.getEmbedded(Arrays.asList('b', 'x'), List).get(0) == 2
+        document.getEmbedded(Arrays.asList('b', 'x'), List).get(1) == 3
+        document.getEmbedded(Arrays.asList('b', 'x'), List).get(2) == 4
+        document.getEmbedded(Arrays.asList('b', 'y', 'm'), String) == 'one'
+        document.getEmbedded(Arrays.asList('b', 'y', 'len'), Integer) == 3
+        document.getEmbedded(Arrays.asList('a.b'), String) == 'two'
+        document.getEmbedded(Arrays.asList('b', 'y'), Document).getString('m') == 'one'
+        document.getEmbedded(Arrays.asList('b', 'y'), Document).getInteger('len') == 3
 
         document.getEmbedded(Arrays.asList('l', 'long'), Long) == 2L
         document.getEmbedded(Arrays.asList('d', 'double'), Double) == 3.0d
@@ -186,7 +186,7 @@ class DocumentSpecification extends Specification {
         thrown(IllegalArgumentException)
 
         when:
-        document.getEmbedded(List.of(), String) == null
+        document.getEmbedded(Arrays.asList(), String) == null
 
         then:
         thrown(IllegalStateException)
@@ -198,19 +198,19 @@ class DocumentSpecification extends Specification {
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(List.of('b', 'y', 'm'), Integer)
+        document.getEmbedded(Arrays.asList('b', 'y', 'm'), Integer)
 
         then:
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(List.of('b', 'x'), Document)
+        document.getEmbedded(Arrays.asList('b', 'x'), Document)
 
         then:
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(List.of('b', 'x', 'm'), String)
+        document.getEmbedded(Arrays.asList('b', 'x', 'm'), String)
 
         then:
         thrown(ClassCastException)

--- a/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/types/DocumentSpecification.groovy
@@ -68,8 +68,8 @@ class DocumentSpecification extends Specification {
     def 'should return a list with elements of the specified class'() {
         when:
         Document doc = Document.parse("{x: 1, y: ['two', 'three'], z: [{a: 'one'}, {b:2}], w: {a: ['One', 'Two']}}")
-                .append('numberList', Arrays.asList(10, 20.5d, 30L))
-        List<String> defaultList = Arrays.asList('a', 'b', 'c')
+                .append('numberList', [10, 20.5d, 30L])
+        List<String> defaultList = ['a', 'b', 'c']
 
         then:
         doc.getList('y', String).get(0) == 'two'
@@ -97,7 +97,7 @@ class DocumentSpecification extends Specification {
     def 'should return specified default value when key is not found'() {
         when:
         Document doc = Document.parse('{x: 1}')
-        List<String> defaultList = Arrays.asList('a', 'b', 'c')
+        List<String> defaultList = ['a', 'b', 'c']
 
         then:
         doc.getList('a', String, defaultList) == defaultList
@@ -131,10 +131,10 @@ class DocumentSpecification extends Specification {
         Document document = Document.parse("{a: 1, b: {x: [2, 3, 4], y: {m: 'one', len: 3}}, 'a.b': 'two'}")
 
         then:
-        document.getEmbedded(Arrays.asList('notAKey'), String) == null
-        document.getEmbedded(Arrays.asList('b', 'y', 'notAKey'), String) == null
-        document.getEmbedded(Arrays.asList('b', 'b', 'm'), String) == null
-        Document.parse('{}').getEmbedded(Arrays.asList('a', 'b'), Integer) == null
+        document.getEmbedded(['notAKey'], String) == null
+        document.getEmbedded(['b', 'y', 'notAKey'], String) == null
+        document.getEmbedded(['b', 'b', 'm'], String) == null
+        Document.parse('{}').getEmbedded(['a', 'b'], Integer) == null
         Document.parse('{b: 1}').getEmbedded(['a'], Integer) == null
         Document.parse('{b: 1}').getEmbedded(['a', 'b'], Integer) == null
         Document.parse('{a: {c: 1}}').getEmbedded(['a', 'b'], Integer) == null
@@ -155,24 +155,24 @@ class DocumentSpecification extends Specification {
                 .append('n', new Document('date', date))
 
         then:
-        document.getEmbedded(Arrays.asList('a'), Integer) == 1
-        document.getEmbedded(Arrays.asList('b', 'x'), List).get(0) == 2
-        document.getEmbedded(Arrays.asList('b', 'x'), List).get(1) == 3
-        document.getEmbedded(Arrays.asList('b', 'x'), List).get(2) == 4
-        document.getEmbedded(Arrays.asList('b', 'y', 'm'), String) == 'one'
-        document.getEmbedded(Arrays.asList('b', 'y', 'len'), Integer) == 3
-        document.getEmbedded(Arrays.asList('a.b'), String) == 'two'
-        document.getEmbedded(Arrays.asList('b', 'y'), Document).getString('m') == 'one'
-        document.getEmbedded(Arrays.asList('b', 'y'), Document).getInteger('len') == 3
+        document.getEmbedded(['a'], Integer) == 1
+        document.getEmbedded(['b', 'x'], List).get(0) == 2
+        document.getEmbedded(['b', 'x'], List).get(1) == 3
+        document.getEmbedded(['b', 'x'], List).get(2) == 4
+        document.getEmbedded(['b', 'y', 'm'], String) == 'one'
+        document.getEmbedded(['b', 'y', 'len'], Integer) == 3
+        document.getEmbedded(['a.b'], String) == 'two'
+        document.getEmbedded(['b', 'y'], Document).getString('m') == 'one'
+        document.getEmbedded(['b', 'y'], Document).getInteger('len') == 3
 
-        document.getEmbedded(Arrays.asList('l', 'long'), Long) == 2L
-        document.getEmbedded(Arrays.asList('d', 'double'), Double) == 3.0d
-        document.getEmbedded(Arrays.asList('l', 'long'), Number) == 2L
-        document.getEmbedded(Arrays.asList('d', 'double'), Number) == 3.0d
-        document.getEmbedded(Arrays.asList('t', 'boolean'), Boolean) == true
-        document.getEmbedded(Arrays.asList('t', 'x'), false) == false
-        document.getEmbedded(Arrays.asList('o', 'objectId'), ObjectId) == objectId
-        document.getEmbedded(Arrays.asList('n', 'date'), Date) == date
+        document.getEmbedded(['l', 'long'], Long) == 2L
+        document.getEmbedded(['d', 'double'], Double) == 3.0d
+        document.getEmbedded(['l', 'long'], Number) == 2L
+        document.getEmbedded(['d', 'double'], Number) == 3.0d
+        document.getEmbedded(['t', 'boolean'], Boolean) == true
+        document.getEmbedded(['t', 'x'], false) == false
+        document.getEmbedded(['o', 'objectId'], ObjectId) == objectId
+        document.getEmbedded(['n', 'date'], Date) == date
     }
 
     def 'should throw an exception getting an embedded value'() {
@@ -186,7 +186,7 @@ class DocumentSpecification extends Specification {
         thrown(IllegalArgumentException)
 
         when:
-        document.getEmbedded(Arrays.asList(), String) == null
+        document.getEmbedded([], String) == null
 
         then:
         thrown(IllegalStateException)
@@ -198,25 +198,25 @@ class DocumentSpecification extends Specification {
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(Arrays.asList('b', 'y', 'm'), Integer)
+        document.getEmbedded(['b', 'y', 'm'], Integer)
 
         then:
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(Arrays.asList('b', 'x'), Document)
+        document.getEmbedded(['b', 'x'], Document)
 
         then:
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(Arrays.asList('b', 'x', 'm'), String)
+        document.getEmbedded(['b', 'x', 'm'], String)
 
         then:
         thrown(ClassCastException)
 
         when:
-        document.getEmbedded(Arrays.asList('b', 'x', 'm'), 'invalid')
+        document.getEmbedded(['b', 'x', 'm'], 'invalid')
 
         then:
         thrown(ClassCastException)


### PR DESCRIPTION
In `DocumentSpecification.groovy`, I have replaced all calls to `List.of`, which causes Evergreen to fail, with `Arrays.asList`.

Evergreen Patch: https://evergreen.mongodb.com/version/5c5486db2a60ed0b009fb247