### PR TITLE
JAVA-3145: Fix CollectionOperationSpecification test

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
@@ -126,7 +126,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 0) })
+    @IgnoreIf({ !serverVersionAtLeast(4, 1) })
     def 'should pass through storage engine options- zstd compression'() {
         given:
         def storageEngineOptions = new BsonDocument('wiredTiger', new BsonDocument('configString', new BsonString('block_compressor=zstd')))


### PR DESCRIPTION
A Zstandard functional test was mistakenly run against 4.0 servers. Changed the test to 4.1.