### PR TITLE
JAVA-1905: implement equals and hashCode methods where Bson instances are returned

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/AggregateOutStageOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/AggregateOutStageOptions.java
@@ -127,6 +127,34 @@ public class AggregateOutStageOptions {
         return uniqueKey;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AggregateOutStageOptions that = (AggregateOutStageOptions) o;
+
+        if (mode != that.mode) {
+            return false;
+        }
+        if (databaseName != null ? !databaseName.equals(that.databaseName) : that.databaseName != null) {
+            return false;
+        }
+        return uniqueKey != null ? uniqueKey.equals(that.uniqueKey) : that.uniqueKey == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mode != null ? mode.hashCode() : 0;
+        result = 31 * result + (databaseName != null ? databaseName.hashCode() : 0);
+        result = 31 * result + (uniqueKey != null ? uniqueKey.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Sets the document describing the unique keys used for comparing documents in the output collection when the mode is either
      * {@code Mode#REPLACE_DOCUMENTS} or {@code Mode#INSERT_DOCUMENTS}.  The format is similar to that used to define a unique index on one

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -16,12 +16,17 @@
 
 package com.mongodb.client.model;
 
+import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.IterableCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -30,6 +35,7 @@ import java.util.List;
 import static com.mongodb.client.model.AggregateOutStageOptions.Mode.REPLACE_COLLECTION;
 import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * Builders for aggregation pipeline stages.
@@ -39,6 +45,8 @@ import static org.bson.assertions.Assertions.notNull;
  * @since 3.1
  */
 public final class Aggregates {
+    private static final CodecRegistry REGISTRY = fromProviders(asList(new BsonValueCodecProvider(), new ValueCodecProvider(),
+            new GeoJsonCodecProvider(), new DocumentCodecProvider(), new IterableCodecProvider()));
 
     /**
      * Creates an $addFields pipeline stage
@@ -493,13 +501,19 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SimplePipelineStage that = (SimplePipelineStage) o;
 
-            if (name != null ? !name.equals(that.name) : that.name != null) return false;
+            if (name != null ? !name.equals(that.name) : that.name != null) {
+                return false;
+            }
             return value != null ? value.equals(that.value) : that.value == null;
         }
 
@@ -560,14 +574,22 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             BucketStage<?, ?> that = (BucketStage<?, ?>) o;
 
-            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) return false;
-            if (boundaries != null ? !boundaries.equals(that.boundaries) : that.boundaries != null) return false;
+            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) {
+                return false;
+            }
+            if (boundaries != null ? !boundaries.equals(that.boundaries) : that.boundaries != null) {
+                return false;
+            }
             return options.equals(that.options);
         }
 
@@ -628,14 +650,22 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             BucketAutoStage<?> that = (BucketAutoStage<?>) o;
 
-            if (buckets != that.buckets) return false;
-            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) return false;
+            if (buckets != that.buckets) {
+                return false;
+            }
+            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) {
+                return false;
+            }
             return options.equals(that.options);
         }
 
@@ -708,15 +738,25 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             LookupStage<?> that = (LookupStage<?>) o;
 
-            if (from != null ? !from.equals(that.from) : that.from != null) return false;
-            if (let != null ? !let.equals(that.let) : that.let != null) return false;
-            if (pipeline != null ? !pipeline.equals(that.pipeline) : that.pipeline != null) return false;
+            if (from != null ? !from.equals(that.from) : that.from != null) {
+                return false;
+            }
+            if (let != null ? !let.equals(that.let) : that.let != null) {
+                return false;
+            }
+            if (pipeline != null ? !pipeline.equals(that.pipeline) : that.pipeline != null) {
+                return false;
+            }
             return as != null ? as.equals(that.as) : that.as == null;
         }
 
@@ -740,9 +780,6 @@ public final class Aggregates {
                     + '}';
         }
     }
-
-
-
 
     private static final class GraphLookupStage<TExpression> implements Bson {
         private final String from;
@@ -797,17 +834,31 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             GraphLookupStage<?> that = (GraphLookupStage<?>) o;
 
-            if (from != null ? !from.equals(that.from) : that.from != null) return false;
-            if (startWith != null ? !startWith.equals(that.startWith) : that.startWith != null) return false;
-            if (connectFromField != null ? !connectFromField.equals(that.connectFromField) : that.connectFromField != null) return false;
-            if (connectToField != null ? !connectToField.equals(that.connectToField) : that.connectToField != null) return false;
-            if (as != null ? !as.equals(that.as) : that.as != null) return false;
+            if (from != null ? !from.equals(that.from) : that.from != null) {
+                return false;
+            }
+            if (startWith != null ? !startWith.equals(that.startWith) : that.startWith != null) {
+                return false;
+            }
+            if (connectFromField != null ? !connectFromField.equals(that.connectFromField) : that.connectFromField != null) {
+                return false;
+            }
+            if (connectToField != null ? !connectToField.equals(that.connectToField) : that.connectToField != null) {
+                return false;
+            }
+            if (as != null ? !as.equals(that.as) : that.as != null) {
+                return false;
+            }
             return options != null ? options.equals(that.options) : that.options == null;
         }
 
@@ -868,13 +919,19 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             GroupStage<?> that = (GroupStage<?>) o;
 
-            if (id != null ? !id.equals(that.id) : that.id != null) return false;
+            if (id != null ? !id.equals(that.id) : that.id != null) {
+                return false;
+            }
             return fieldAccumulators != null ? fieldAccumulators.equals(that.fieldAccumulators) : that.fieldAccumulators == null;
         }
 
@@ -917,9 +974,13 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SortByCountStage<?> that = (SortByCountStage<?>) o;
 
@@ -968,9 +1029,13 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             FacetStage that = (FacetStage) o;
 
@@ -1015,9 +1080,13 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             AddFieldsStage that = (AddFieldsStage) o;
 
@@ -1060,9 +1129,13 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             ReplaceRootStage<?> that = (ReplaceRootStage<?>) o;
 
@@ -1138,13 +1211,19 @@ public final class Aggregates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             OutStage outStage = (OutStage) o;
 
-            if (collectionName != null ? !collectionName.equals(outStage.collectionName) : outStage.collectionName != null) return false;
+            if (collectionName != null ? !collectionName.equals(outStage.collectionName) : outStage.collectionName != null) {
+                return false;
+            }
             return options != null ? options.equals(outStage.options) : outStage.options == null;
         }
 

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -16,17 +16,12 @@
 
 package com.mongodb.client.model;
 
-import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
-import org.bson.codecs.BsonValueCodecProvider;
-import org.bson.codecs.DocumentCodecProvider;
-import org.bson.codecs.IterableCodecProvider;
-import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -35,7 +30,6 @@ import java.util.List;
 import static com.mongodb.client.model.AggregateOutStageOptions.Mode.REPLACE_COLLECTION;
 import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.notNull;
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * Builders for aggregation pipeline stages.
@@ -45,8 +39,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  * @since 3.1
  */
 public final class Aggregates {
-    private static final CodecRegistry REGISTRY = fromProviders(asList(new BsonValueCodecProvider(), new ValueCodecProvider(),
-            new GeoJsonCodecProvider(), new DocumentCodecProvider(), new IterableCodecProvider()));
 
     /**
      * Creates an $addFields pipeline stage

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -493,6 +493,24 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SimplePipelineStage that = (SimplePipelineStage) o;
+
+            if (name != null ? !name.equals(that.name) : that.name != null) return false;
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                            + "name='" + name + '\''
@@ -542,6 +560,26 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BucketStage<?, ?> that = (BucketStage<?, ?>) o;
+
+            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) return false;
+            if (boundaries != null ? !boundaries.equals(that.boundaries) : that.boundaries != null) return false;
+            return options.equals(that.options);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = groupBy != null ? groupBy.hashCode() : 0;
+            result = 31 * result + (boundaries != null ? boundaries.hashCode() : 0);
+            result = 31 * result + options.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                 + "name='$bucket'"
@@ -587,6 +625,26 @@ public final class Aggregates {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BucketAutoStage<?> that = (BucketAutoStage<?>) o;
+
+            if (buckets != that.buckets) return false;
+            if (groupBy != null ? !groupBy.equals(that.groupBy) : that.groupBy != null) return false;
+            return options.equals(that.options);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = groupBy != null ? groupBy.hashCode() : 0;
+            result = 31 * result + buckets;
+            result = 31 * result + options.hashCode();
+            return result;
         }
 
         @Override
@@ -647,6 +705,28 @@ public final class Aggregates {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LookupStage<?> that = (LookupStage<?>) o;
+
+            if (from != null ? !from.equals(that.from) : that.from != null) return false;
+            if (let != null ? !let.equals(that.let) : that.let != null) return false;
+            if (pipeline != null ? !pipeline.equals(that.pipeline) : that.pipeline != null) return false;
+            return as != null ? as.equals(that.as) : that.as == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = from != null ? from.hashCode() : 0;
+            result = 31 * result + (let != null ? let.hashCode() : 0);
+            result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
+            result = 31 * result + (as != null ? as.hashCode() : 0);
+            return result;
         }
 
         @Override
@@ -717,6 +797,32 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            GraphLookupStage<?> that = (GraphLookupStage<?>) o;
+
+            if (from != null ? !from.equals(that.from) : that.from != null) return false;
+            if (startWith != null ? !startWith.equals(that.startWith) : that.startWith != null) return false;
+            if (connectFromField != null ? !connectFromField.equals(that.connectFromField) : that.connectFromField != null) return false;
+            if (connectToField != null ? !connectToField.equals(that.connectToField) : that.connectToField != null) return false;
+            if (as != null ? !as.equals(that.as) : that.as != null) return false;
+            return options != null ? options.equals(that.options) : that.options == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = from != null ? from.hashCode() : 0;
+            result = 31 * result + (startWith != null ? startWith.hashCode() : 0);
+            result = 31 * result + (connectFromField != null ? connectFromField.hashCode() : 0);
+            result = 31 * result + (connectToField != null ? connectToField.hashCode() : 0);
+            result = 31 * result + (as != null ? as.hashCode() : 0);
+            result = 31 * result + (options != null ? options.hashCode() : 0);
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                 + "name='$graphLookup'"
@@ -762,6 +868,24 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            GroupStage<?> that = (GroupStage<?>) o;
+
+            if (id != null ? !id.equals(that.id) : that.id != null) return false;
+            return fieldAccumulators != null ? fieldAccumulators.equals(that.fieldAccumulators) : that.fieldAccumulators == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id != null ? id.hashCode() : 0;
+            result = 31 * result + (fieldAccumulators != null ? fieldAccumulators.hashCode() : 0);
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                            + "name='$group'"
@@ -790,6 +914,21 @@ public final class Aggregates {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SortByCountStage<?> that = (SortByCountStage<?>) o;
+
+            return filter != null ? filter.equals(that.filter) : that.filter == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return filter != null ? filter.hashCode() : 0;
         }
 
         @Override
@@ -829,6 +968,21 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FacetStage that = (FacetStage) o;
+
+            return facets != null ? facets.equals(that.facets) : that.facets == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return facets != null ? facets.hashCode() : 0;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                 + "name='$facet', "
@@ -861,6 +1015,21 @@ public final class Aggregates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            AddFieldsStage that = (AddFieldsStage) o;
+
+            return fields != null ? fields.equals(that.fields) : that.fields == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return fields != null ? fields.hashCode() : 0;
+        }
+
+        @Override
         public String toString() {
             return "Stage{"
                 + "name='$addFields', "
@@ -888,6 +1057,21 @@ public final class Aggregates {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ReplaceRootStage<?> that = (ReplaceRootStage<?>) o;
+
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
         }
 
         @Override
@@ -951,6 +1135,24 @@ public final class Aggregates {
 
             writer.writeEndDocument();
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OutStage outStage = (OutStage) o;
+
+            if (collectionName != null ? !collectionName.equals(outStage.collectionName) : outStage.collectionName != null) return false;
+            return options != null ? options.equals(outStage.options) : outStage.options == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = collectionName != null ? collectionName.hashCode() : 0;
+            result = 31 * result + (options != null ? options.hashCode() : 0);
+            return result;
         }
 
         private boolean optionsAreAllDefault() {

--- a/driver-core/src/main/com/mongodb/client/model/BsonField.java
+++ b/driver-core/src/main/com/mongodb/client/model/BsonField.java
@@ -58,6 +58,30 @@ public final class BsonField {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BsonField bsonField = (BsonField) o;
+
+        if (!name.equals(bsonField.name)) {
+            return false;
+        }
+        return value.equals(bsonField.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + value.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "BsonField{"
                + "name='" + name + '\''

--- a/driver-core/src/main/com/mongodb/client/model/BucketAutoOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/BucketAutoOptions.java
@@ -86,6 +86,30 @@ public class BucketAutoOptions {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BucketAutoOptions that = (BucketAutoOptions) o;
+
+        if (output != null ? !output.equals(that.output) : that.output != null) {
+            return false;
+        }
+        return granularity == that.granularity;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = output != null ? output.hashCode() : 0;
+        result = 31 * result + (granularity != null ? granularity.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "BucketAutoOptions{"
                 + "output=" + output

--- a/driver-core/src/main/com/mongodb/client/model/BucketOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/BucketOptions.java
@@ -84,6 +84,30 @@ public class BucketOptions {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BucketOptions that = (BucketOptions) o;
+
+        if (defaultBucket != null ? !defaultBucket.equals(that.defaultBucket) : that.defaultBucket != null) {
+            return false;
+        }
+        return output != null ? output.equals(that.output) : that.output == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = defaultBucket != null ? defaultBucket.hashCode() : 0;
+        result = 31 * result + (output != null ? output.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "BucketOptions{"
                 + "defaultBucket=" + defaultBucket

--- a/driver-core/src/main/com/mongodb/client/model/Facet.java
+++ b/driver-core/src/main/com/mongodb/client/model/Facet.java
@@ -65,6 +65,30 @@ public class Facet {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Facet facet = (Facet) o;
+
+        if (name != null ? !name.equals(facet.name) : facet.name != null) {
+            return false;
+        }
+        return pipeline != null ? pipeline.equals(facet.pipeline) : facet.pipeline == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "Facet{"
                 + "name='" + name + '\''

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -895,13 +894,19 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SimpleFilter that = (SimpleFilter) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
             return value.equals(that.value);
         }
 
@@ -945,14 +950,22 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             OperatorFilter<?> that = (OperatorFilter<?>) o;
 
-            if (!operatorName.equals(that.operatorName)) return false;
-            if (!fieldName.equals(that.fieldName)) return false;
+            if (!operatorName.equals(that.operatorName)) {
+                return false;
+            }
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
             return value != null ? value.equals(that.value) : that.value == null;
         }
 
@@ -1041,9 +1054,13 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             AndFilter andFilter = (AndFilter) o;
 
@@ -1100,13 +1117,19 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             OrNorFilter that = (OrNorFilter) o;
 
-            if (operator != that.operator) return false;
+            if (operator != that.operator) {
+                return false;
+            }
             return filters.equals(that.filters);
         }
 
@@ -1158,14 +1181,22 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             IterableOperatorFilter<?> that = (IterableOperatorFilter<?>) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
-            if (!operatorName.equals(that.operatorName)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
+            if (!operatorName.equals(that.operatorName)) {
+                return false;
+            }
             return values.equals(that.values);
         }
 
@@ -1205,13 +1236,19 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SimpleEncodingFilter<?> that = (SimpleEncodingFilter<?>) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
             return value != null ? value.equals(that.value) : that.value == null;
         }
 
@@ -1280,9 +1317,13 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             NotFilter notFilter = (NotFilter) o;
 
@@ -1346,16 +1387,28 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             GeometryOperatorFilter<?> that = (GeometryOperatorFilter<?>) o;
 
-            if (operatorName != null ? !operatorName.equals(that.operatorName) : that.operatorName != null) return false;
-            if (!fieldName.equals(that.fieldName)) return false;
-            if (!geometry.equals(that.geometry)) return false;
-            if (maxDistance != null ? !maxDistance.equals(that.maxDistance) : that.maxDistance != null) return false;
+            if (operatorName != null ? !operatorName.equals(that.operatorName) : that.operatorName != null) {
+                return false;
+            }
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
+            if (!geometry.equals(that.geometry)) {
+                return false;
+            }
+            if (maxDistance != null ? !maxDistance.equals(that.maxDistance) : that.maxDistance != null) {
+                return false;
+            }
             return minDistance != null ? minDistance.equals(that.minDistance) : that.minDistance == null;
         }
 
@@ -1412,13 +1465,19 @@ public final class Filters {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             TextFilter that = (TextFilter) o;
 
-            if (search != null ? !search.equals(that.search) : that.search != null) return false;
+            if (search != null ? !search.equals(that.search) : that.search != null) {
+                return false;
+            }
             return textSearchOptions != null ? textSearchOptions.equals(that.textSearchOptions) : that.textSearchOptions == null;
         }
 

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -894,6 +895,24 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SimpleFilter that = (SimpleFilter) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + value.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return operatorFilterToString(fieldName, "$eq", value);
         }
@@ -923,6 +942,26 @@ public final class Filters {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OperatorFilter<?> that = (OperatorFilter<?>) o;
+
+            if (!operatorName.equals(that.operatorName)) return false;
+            if (!fieldName.equals(that.fieldName)) return false;
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = operatorName.hashCode();
+            result = 31 * result + fieldName.hashCode();
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
         }
 
         @Override
@@ -1002,6 +1041,21 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            AndFilter andFilter = (AndFilter) o;
+
+            return filters.equals(andFilter.filters);
+        }
+
+        @Override
+        public int hashCode() {
+            return filters.hashCode();
+        }
+
+        @Override
         public String toString() {
             return "And Filter{"
                            + "filters=" + filters
@@ -1046,6 +1100,24 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OrNorFilter that = (OrNorFilter) o;
+
+            if (operator != that.operator) return false;
+            return filters.equals(that.filters);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = operator.hashCode();
+            result = 31 * result + filters.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return operator.toStringName + " Filter{"
                            + "filters=" + filters
@@ -1086,6 +1158,26 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            IterableOperatorFilter<?> that = (IterableOperatorFilter<?>) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            if (!operatorName.equals(that.operatorName)) return false;
+            return values.equals(that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + operatorName.hashCode();
+            result = 31 * result + values.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return operatorFilterToString(fieldName, operatorName, values);
         }
@@ -1110,6 +1202,24 @@ public final class Filters {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SimpleEncodingFilter<?> that = (SimpleEncodingFilter<?>) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
         }
 
         @Override
@@ -1170,6 +1280,21 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NotFilter notFilter = (NotFilter) o;
+
+            return filter.equals(notFilter.filter);
+        }
+
+        @Override
+        public int hashCode() {
+            return filter.hashCode();
+        }
+
+        @Override
         public String toString() {
             return "Not Filter{"
                            + "filter=" + filter
@@ -1221,6 +1346,30 @@ public final class Filters {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            GeometryOperatorFilter<?> that = (GeometryOperatorFilter<?>) o;
+
+            if (operatorName != null ? !operatorName.equals(that.operatorName) : that.operatorName != null) return false;
+            if (!fieldName.equals(that.fieldName)) return false;
+            if (!geometry.equals(that.geometry)) return false;
+            if (maxDistance != null ? !maxDistance.equals(that.maxDistance) : that.maxDistance != null) return false;
+            return minDistance != null ? minDistance.equals(that.minDistance) : that.minDistance == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = operatorName != null ? operatorName.hashCode() : 0;
+            result = 31 * result + fieldName.hashCode();
+            result = 31 * result + geometry.hashCode();
+            result = 31 * result + (maxDistance != null ? maxDistance.hashCode() : 0);
+            result = 31 * result + (minDistance != null ? minDistance.hashCode() : 0);
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Geometry Operator Filter{"
                            + "fieldName='" + fieldName + '\''
@@ -1260,6 +1409,24 @@ public final class Filters {
                 searchDocument.put("$diacriticSensitive", BsonBoolean.valueOf(diacriticSensitive));
             }
             return new BsonDocument("$text", searchDocument);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TextFilter that = (TextFilter) o;
+
+            if (search != null ? !search.equals(that.search) : that.search != null) return false;
+            return textSearchOptions != null ? textSearchOptions.equals(that.textSearchOptions) : that.textSearchOptions == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = search != null ? search.hashCode() : 0;
+            result = 31 * result + (textSearchOptions != null ? textSearchOptions.hashCode() : 0);
+            return result;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/client/model/GraphLookupOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/GraphLookupOptions.java
@@ -91,6 +91,35 @@ public final class GraphLookupOptions {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GraphLookupOptions that = (GraphLookupOptions) o;
+
+        if (maxDepth != null ? !maxDepth.equals(that.maxDepth) : that.maxDepth != null) {
+            return false;
+        }
+        if (depthField != null ? !depthField.equals(that.depthField) : that.depthField != null) {
+            return false;
+        }
+        return restrictSearchWithMatch != null ? restrictSearchWithMatch.equals(that.restrictSearchWithMatch)
+                : that.restrictSearchWithMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = maxDepth != null ? maxDepth.hashCode() : 0;
+        result = 31 * result + (depthField != null ? depthField.hashCode() : 0);
+        result = 31 * result + (restrictSearchWithMatch != null ? restrictSearchWithMatch.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder()
             .append("GraphLookupOptions{");

--- a/driver-core/src/main/com/mongodb/client/model/Indexes.java
+++ b/driver-core/src/main/com/mongodb/client/model/Indexes.java
@@ -136,7 +136,7 @@ public final class Indexes {
      * indexes are only usable via commands and so always return all results at once..
      * </p>
      *
-     * @param fieldName the field to create a geoHaystack index on
+     * @param fieldName  the field to create a geoHaystack index on
      * @param additional the additional field that forms the geoHaystack index key
      * @return the index specification
      * @mongodb.driver.manual core/geohaystack geoHaystack index
@@ -199,20 +199,7 @@ public final class Indexes {
      * @mongodb.driver.manual core/index-compound compoundIndex
      */
     public static Bson compoundIndex(final List<? extends Bson> indexes) {
-        notNull("indexes", indexes);
-        return new Bson() {
-            @Override
-            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
-                BsonDocument compoundIndex = new BsonDocument();
-                for (Bson index : indexes) {
-                    BsonDocument indexDocument = index.toBsonDocument(documentClass, codecRegistry);
-                    for (String key : indexDocument.keySet()) {
-                        compoundIndex.append(key, indexDocument.get(key));
-                    }
-                }
-                return compoundIndex;
-            }
-        };
+        return new CompoundIndex(indexes);
     }
 
     private static Bson compoundIndex(final List<String> fieldNames, final BsonValue value) {
@@ -222,4 +209,45 @@ public final class Indexes {
         }
         return document;
     }
+
+    private static class CompoundIndex implements Bson {
+        private final List<? extends Bson> indexes;
+
+        CompoundIndex(final List<? extends Bson> indexes) {
+            notNull("indexes", indexes);
+            this.indexes = indexes;
+        }
+
+        @Override
+        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocument compoundIndex = new BsonDocument();
+            for (Bson index : indexes) {
+                BsonDocument indexDocument = index.toBsonDocument(documentClass, codecRegistry);
+                for (String key : indexDocument.keySet()) {
+                    compoundIndex.append(key, indexDocument.get(key));
+                }
+            }
+            return compoundIndex;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            CompoundIndex that = (CompoundIndex) o;
+
+            return indexes.equals(that.indexes);
+        }
+
+        @Override
+        public int hashCode() {
+            return indexes.hashCode();
+        }
+    }
 }
+

--- a/driver-core/src/main/com/mongodb/client/model/Indexes.java
+++ b/driver-core/src/main/com/mongodb/client/model/Indexes.java
@@ -136,7 +136,7 @@ public final class Indexes {
      * indexes are only usable via commands and so always return all results at once..
      * </p>
      *
-     * @param fieldName  the field to create a geoHaystack index on
+     * @param fieldName the field to create a geoHaystack index on
      * @param additional the additional field that forms the geoHaystack index key
      * @return the index specification
      * @mongodb.driver.manual core/geohaystack geoHaystack index

--- a/driver-core/src/main/com/mongodb/client/model/Projections.java
+++ b/driver-core/src/main/com/mongodb/client/model/Projections.java
@@ -212,6 +212,25 @@ public final class Projections {
         }
 
         @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            FieldsProjection that = (FieldsProjection) o;
+
+            return projections != null ? projections.equals(that.projections) : that.projections == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return projections != null ? projections.hashCode() : 0;
+        }
+
+        @Override
         public String toString() {
             return "Projections{"
                            + "projections=" + projections
@@ -232,6 +251,30 @@ public final class Projections {
         @Override
         public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
             return new BsonDocument(fieldName, new BsonDocument("$elemMatch", filter.toBsonDocument(documentClass, codecRegistry)));
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ElemMatchFilterProjection that = (ElemMatchFilterProjection) o;
+
+            if (fieldName != null ? !fieldName.equals(that.fieldName) : that.fieldName != null) {
+                return false;
+            }
+            return filter != null ? filter.equals(that.filter) : that.filter == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName != null ? fieldName.hashCode() : 0;
+            result = 31 * result + (filter != null ? filter.hashCode() : 0);
+            return result;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/client/model/PushOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/PushOptions.java
@@ -135,6 +135,38 @@ public class PushOptions {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PushOptions that = (PushOptions) o;
+
+        if (position != null ? !position.equals(that.position) : that.position != null) {
+            return false;
+        }
+        if (slice != null ? !slice.equals(that.slice) : that.slice != null) {
+            return false;
+        }
+        if (sort != null ? !sort.equals(that.sort) : that.sort != null) {
+            return false;
+        }
+        return sortDocument != null ? sortDocument.equals(that.sortDocument) : that.sortDocument == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = position != null ? position.hashCode() : 0;
+        result = 31 * result + (slice != null ? slice.hashCode() : 0);
+        result = 31 * result + (sort != null ? sort.hashCode() : 0);
+        result = 31 * result + (sortDocument != null ? sortDocument.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "Push Options{"
                        + "position=" + position

--- a/driver-core/src/main/com/mongodb/client/model/SimpleExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/SimpleExpression.java
@@ -43,6 +43,30 @@ class SimpleExpression<TExpression> implements Bson {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SimpleExpression<?> that = (SimpleExpression<?>) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        return expression != null ? expression.equals(that.expression) : that.expression == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (expression != null ? expression.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "Expression{"
                        + "name='" + name + '\''

--- a/driver-core/src/main/com/mongodb/client/model/Sorts.java
+++ b/driver-core/src/main/com/mongodb/client/model/Sorts.java
@@ -149,6 +149,25 @@ public final class Sorts {
         }
 
         @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            CompoundSort that = (CompoundSort) o;
+
+            return sorts != null ? sorts.equals(that.sorts) : that.sorts == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return sorts != null ? sorts.hashCode() : 0;
+        }
+
+        @Override
         public String toString() {
             return "Compound Sort{"
                            + "sorts=" + sorts

--- a/driver-core/src/main/com/mongodb/client/model/TextSearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/TextSearchOptions.java
@@ -98,6 +98,34 @@ public final class TextSearchOptions {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TextSearchOptions that = (TextSearchOptions) o;
+
+        if (language != null ? !language.equals(that.language) : that.language != null) {
+            return false;
+        }
+        if (caseSensitive != null ? !caseSensitive.equals(that.caseSensitive) : that.caseSensitive != null) {
+            return false;
+        }
+        return diacriticSensitive != null ? diacriticSensitive.equals(that.diacriticSensitive) : that.diacriticSensitive == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = language != null ? language.hashCode() : 0;
+        result = 31 * result + (caseSensitive != null ? caseSensitive.hashCode() : 0);
+        result = 31 * result + (diacriticSensitive != null ? diacriticSensitive.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "Text Search Options{"
                        + "language='" + language + '\''

--- a/driver-core/src/main/com/mongodb/client/model/Updates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Updates.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.model;
 
+import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -23,6 +24,10 @@ import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.IterableCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -32,6 +37,7 @@ import java.util.Map;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.client.model.BuildersHelper.encodeValue;
 import static java.util.Arrays.asList;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * A factory for document updates. A convenient way to use this class is to statically import all of its methods, which allows usage like:
@@ -43,6 +49,8 @@ import static java.util.Arrays.asList;
  * @mongodb.driver.manual reference/operator/update/ Update Operators
  */
 public final class Updates {
+    private static final CodecRegistry REGISTRY = fromProviders(asList(new BsonValueCodecProvider(), new ValueCodecProvider(),
+            new GeoJsonCodecProvider(), new DocumentCodecProvider(), new IterableCodecProvider()));
 
     /**
      * Combine a list of updates into a single update.
@@ -456,13 +464,19 @@ public final class Updates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SimpleBsonKeyValue that = (SimpleBsonKeyValue) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
             return value.equals(that.value);
         }
 
@@ -511,14 +525,22 @@ public final class Updates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             SimpleUpdate<?> that = (SimpleUpdate<?>) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
-            if (value != null ? !value.equals(that.value) : that.value != null) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
+            if (value != null ? !value.equals(that.value) : that.value != null) {
+                return false;
+            }
             return operator != null ? operator.equals(that.operator) : that.operator == null;
         }
 
@@ -589,14 +611,22 @@ public final class Updates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             WithEachUpdate<?> that = (WithEachUpdate<?>) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
-            if (!values.equals(that.values)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
+            if (!values.equals(that.values)) {
+                return false;
+            }
             return operator != null ? operator.equals(that.operator) : that.operator == null;
         }
 
@@ -652,6 +682,30 @@ public final class Updates {
         }
 
         @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            PushUpdate<?> that = (PushUpdate<?>) o;
+
+            return options.equals(that.options);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + options.hashCode();
+            return result;
+        }
+
+        @Override
         protected String additionalFieldsToString() {
             return ", options=" + options;
         }
@@ -690,13 +744,19 @@ public final class Updates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             PullAllUpdate<?> that = (PullAllUpdate<?>) o;
 
-            if (!fieldName.equals(that.fieldName)) return false;
+            if (!fieldName.equals(that.fieldName)) {
+                return false;
+            }
             return values.equals(that.values);
         }
 
@@ -748,9 +808,13 @@ public final class Updates {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             CompositeUpdate that = (CompositeUpdate) o;
 

--- a/driver-core/src/main/com/mongodb/client/model/Updates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Updates.java
@@ -456,6 +456,24 @@ public final class Updates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SimpleBsonKeyValue that = (SimpleBsonKeyValue) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + value.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "SimpleBsonKeyValue{"
                     + "fieldName='" + fieldName + '\''
@@ -490,6 +508,26 @@ public final class Updates {
             writer.writeEndDocument();
 
             return writer.getDocument();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SimpleUpdate<?> that = (SimpleUpdate<?>) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            if (value != null ? !value.equals(that.value) : that.value != null) return false;
+            return operator != null ? operator.equals(that.operator) : that.operator == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            result = 31 * result + (operator != null ? operator.hashCode() : 0);
+            return result;
         }
 
         @Override
@@ -548,6 +586,26 @@ public final class Updates {
 
         protected String additionalFieldsToString() {
             return "";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            WithEachUpdate<?> that = (WithEachUpdate<?>) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            if (!values.equals(that.values)) return false;
+            return operator != null ? operator.equals(that.operator) : that.operator == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + values.hashCode();
+            result = 31 * result + (operator != null ? operator.hashCode() : 0);
+            return result;
         }
 
         @Override
@@ -632,6 +690,24 @@ public final class Updates {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            PullAllUpdate<?> that = (PullAllUpdate<?>) o;
+
+            if (!fieldName.equals(that.fieldName)) return false;
+            return values.equals(that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fieldName.hashCode();
+            result = 31 * result + values.hashCode();
+            return result;
+        }
+
+        @Override
         public String toString() {
             return "Update{"
                            + "fieldName='" + fieldName + '\''
@@ -669,6 +745,21 @@ public final class Updates {
             }
 
             return document;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            CompositeUpdate that = (CompositeUpdate) o;
+
+            return updates != null ? updates.equals(that.updates) : that.updates == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return updates != null ? updates.hashCode() : 0;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/client/model/Updates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Updates.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client.model;
 
-import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -24,10 +23,6 @@ import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.codecs.BsonValueCodecProvider;
-import org.bson.codecs.DocumentCodecProvider;
-import org.bson.codecs.IterableCodecProvider;
-import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -37,7 +32,6 @@ import java.util.Map;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.client.model.BuildersHelper.encodeValue;
 import static java.util.Arrays.asList;
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * A factory for document updates. A convenient way to use this class is to statically import all of its methods, which allows usage like:
@@ -49,8 +43,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  * @mongodb.driver.manual reference/operator/update/ Update Operators
  */
 public final class Updates {
-    private static final CodecRegistry REGISTRY = fromProviders(asList(new BsonValueCodecProvider(), new ValueCodecProvider(),
-            new GeoJsonCodecProvider(), new DocumentCodecProvider(), new IterableCodecProvider()));
 
     /**
      * Combine a list of updates into a single update.

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -383,4 +383,385 @@ class AggregatesSpecification extends Specification {
     def toBson(Bson bson) {
         bson.toBsonDocument(BsonDocument, registry)
     }
+
+    def 'should test equals for SimplePipelineStage'() {
+        expect:
+        match(eq('author', 'dave')).equals(match(eq('author', 'dave')))
+        project(fields(include('title', 'author'), computed('lastName', '$author.last')))
+                .equals(project(fields(include('title', 'author'), computed('lastName', '$author.last'))))
+        sort(ascending('title', 'author')).equals(sort(ascending('title', 'author')))
+        !sort(ascending('title', 'author')).equals(sort(descending('title', 'author')))
+    }
+
+    def 'should test hashCode for SimplePipelineStage'() {
+        expect:
+        match(eq('author', 'dave')).hashCode() == match(eq('author', 'dave')).hashCode()
+        project(fields(include('title', 'author'), computed('lastName', '$author.last'))).hashCode() ==
+                project(fields(include('title', 'author'), computed('lastName', '$author.last'))).hashCode()
+        sort(ascending('title', 'author')).hashCode() == sort(ascending('title', 'author')).hashCode()
+        sort(ascending('title', 'author')).hashCode() != sort(descending('title', 'author')).hashCode()
+    }
+
+    def 'should test equals for BucketStage'() {
+        expect:
+        bucket('$screenSize', [0, 24, 32, 50, 100000]).equals(bucket('$screenSize', [0, 24, 32, 50, 100000]))
+    }
+
+    def 'should test hashCode for BucketStage'() {
+        expect:
+        bucket('$screenSize', [0, 24, 32, 50, 100000]).hashCode() == bucket('$screenSize', [0, 24, 32, 50, 100000]).hashCode()
+        bucket('$screenSize', [0, 24, 32, 50, 100000]).hashCode() != bucket('$screenSize', [0, 24, 32, 50, 10000]).hashCode()
+    }
+
+    def 'should test equals for BucketAutoStage'() {
+        expect:
+        bucketAuto('$price', 4).equals(bucketAuto('$price', 4))
+        bucketAuto('$price', 4, new BucketAutoOptions()
+                .output(sum('count', 1),
+                        avg('avgPrice', '$price')))
+                .equals(bucketAuto('$price', 4, new BucketAutoOptions()
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))))
+        bucketAuto('$price', 4, new BucketAutoOptions()
+                .granularity(R5)
+                .output(sum('count', 1),
+                avg('avgPrice', '$price')))
+                .equals(bucketAuto('$price', 4, new BucketAutoOptions()
+                .granularity(R5)
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))))
+    }
+
+    def 'should test hashCode for BucketAutoStage'() {
+        expect:
+        bucketAuto('$price', 4).hashCode() == bucketAuto('$price', 4).hashCode()
+        bucketAuto('$price', 4, new BucketAutoOptions()
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))).hashCode() ==
+                bucketAuto('$price', 4, new BucketAutoOptions()
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))).hashCode()
+        bucketAuto('$price', 4, new BucketAutoOptions()
+                .granularity(R5)
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))).hashCode() ==
+                bucketAuto('$price', 4, new BucketAutoOptions()
+                .granularity(R5)
+                .output(sum('count', 1),
+                avg('avgPrice', '$price'))).hashCode()
+    }
+
+    def 'should test equals for LookupStage'() {
+        expect:
+        lookup('from', 'localField', 'foreignField', 'as')
+                .equals(lookup('from', 'localField', 'foreignField', 'as'))
+
+        List<Bson> pipeline = asList(match(expr(new Document('$eq', asList('x', '1')))))
+        lookup('from', asList(new Variable('var1', 'expression1')), pipeline, 'as')
+                .equals(lookup('from', asList(new Variable('var1', 'expression1')), pipeline, 'as'))
+
+        lookup('from', pipeline, 'as').equals(lookup('from', pipeline, 'as'))
+    }
+
+    def 'should test hashCode for LookupStage'() {
+        expect:
+        lookup('from', 'localField', 'foreignField', 'as').hashCode() ==
+                lookup('from', 'localField', 'foreignField', 'as').hashCode()
+
+        List<Bson> pipeline = asList(match(expr(new Document('$eq', asList('x', '1')))))
+        lookup('from', asList(new Variable('var1', 'expression1')), pipeline, 'as').hashCode() ==
+                lookup('from', asList(new Variable('var1', 'expression1')), pipeline, 'as').hashCode()
+
+        lookup('from', pipeline, 'as').hashCode() == lookup('from', pipeline, 'as').hashCode()
+    }
+
+    def 'should test equals for GraphLookupStage'() {
+        expect:
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork')
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork'))
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions().maxDepth(1))
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork',
+                new GraphLookupOptions().maxDepth(1)))
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions().depthField('master'))
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork',
+                new GraphLookupOptions().depthField('master')))
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .restrictSearchWithMatch(eq('hobbies', 'golf')))
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .restrictSearchWithMatch(eq('hobbies', 'golf'))))
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master'))
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master')))
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master').restrictSearchWithMatch(eq('hobbies', 'golf')))
+                .equals(graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master').restrictSearchWithMatch(eq('hobbies', 'golf'))))
+    }
+
+    def 'should test hashCode for GraphLookupStage'() {
+        expect:
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork').hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork').hashCode()
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions().maxDepth(1))
+                .hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork',
+                new GraphLookupOptions().maxDepth(1)).hashCode()
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions().depthField('master'))
+                .hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork',
+                new GraphLookupOptions().depthField('master')).hashCode()
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .restrictSearchWithMatch(eq('hobbies', 'golf'))).hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .restrictSearchWithMatch(eq('hobbies', 'golf'))).hashCode()
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master')).hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master')).hashCode()
+
+        graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master').restrictSearchWithMatch(eq('hobbies', 'golf'))).hashCode() ==
+                graphLookup('contacts', '$friends', 'friends', 'name', 'socialNetwork', new GraphLookupOptions()
+                .maxDepth(1).depthField('master').restrictSearchWithMatch(eq('hobbies', 'golf'))).hashCode()
+    }
+
+    def 'should test equals for GroupStage'() {
+        expect:
+        group('$customerId').equals(group('$customerId'))
+        group(null).equals(group(null))
+
+        group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }'))
+                .equals(group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')))
+
+        def groupDocument = parse('''{
+                            $group : {
+                                      _id : null,
+                                      sum: { $sum: { $multiply: [ "$price", "$quantity" ] } },
+                                      avg: { $avg: "$quantity" },
+                                      min: { $min: "$quantity" },
+                                      max: { $max: "$quantity" },
+                                      first: { $first: "$quantity" },
+                                      last: { $last: "$quantity" },
+                                      all: { $push: "$quantity" },
+                                      unique: { $addToSet: "$quantity" },
+                                      stdDevPop: { $stdDevPop: "$quantity" },
+                                      stdDevSamp: { $stdDevSamp: "$quantity" }
+                                     }
+                                  }''')
+        group(null,
+                sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
+                avg('avg', '$quantity'),
+                min('min', '$quantity'),
+                max('max', '$quantity'),
+                first('first', '$quantity'),
+                last('last', '$quantity'),
+                push('all', '$quantity'),
+                addToSet('unique', '$quantity'),
+                stdDevPop('stdDevPop', '$quantity'),
+                stdDevSamp('stdDevSamp', '$quantity')
+        ).equals(group(null,
+                sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
+                avg('avg', '$quantity'),
+                min('min', '$quantity'),
+                max('max', '$quantity'),
+                first('first', '$quantity'),
+                last('last', '$quantity'),
+                push('all', '$quantity'),
+                addToSet('unique', '$quantity'),
+                stdDevPop('stdDevPop', '$quantity'),
+                stdDevSamp('stdDevSamp', '$quantity')
+        ))
+    }
+
+    def 'should test hashCode for GroupStage'() {
+        expect:
+        group('$customerId').hashCode() == group('$customerId').hashCode()
+        group(null).hashCode() == group(null).hashCode()
+
+        group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')).hashCode() ==
+                group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')).hashCode()
+
+        def groupDocument = parse('''{
+                            $group : {
+                                      _id : null,
+                                      sum: { $sum: { $multiply: [ "$price", "$quantity" ] } },
+                                      avg: { $avg: "$quantity" },
+                                      min: { $min: "$quantity" },
+                                      max: { $max: "$quantity" },
+                                      first: { $first: "$quantity" },
+                                      last: { $last: "$quantity" },
+                                      all: { $push: "$quantity" },
+                                      unique: { $addToSet: "$quantity" },
+                                      stdDevPop: { $stdDevPop: "$quantity" },
+                                      stdDevSamp: { $stdDevSamp: "$quantity" }
+                                     }
+                                  }''')
+        group(null,
+                sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
+                avg('avg', '$quantity'),
+                min('min', '$quantity'),
+                max('max', '$quantity'),
+                first('first', '$quantity'),
+                last('last', '$quantity'),
+                push('all', '$quantity'),
+                addToSet('unique', '$quantity'),
+                stdDevPop('stdDevPop', '$quantity'),
+                stdDevSamp('stdDevSamp', '$quantity')
+        ).hashCode() ==
+                group(null,
+                sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
+                avg('avg', '$quantity'),
+                min('min', '$quantity'),
+                max('max', '$quantity'),
+                first('first', '$quantity'),
+                last('last', '$quantity'),
+                push('all', '$quantity'),
+                addToSet('unique', '$quantity'),
+                stdDevPop('stdDevPop', '$quantity'),
+                stdDevSamp('stdDevSamp', '$quantity')).hashCode()
+    }
+
+    def 'should test equals for SortByCountStage'() {
+        expect:
+        sortByCount('someField').equals(sortByCount('someField'))
+        sortByCount(new Document('$floor', '$x')).equals(sortByCount(new Document('$floor', '$x')))
+    }
+
+    def 'should test hashCode for SortByCountStage'() {
+        expect:
+        sortByCount('someField').hashCode() == sortByCount('someField').hashCode()
+        sortByCount(new Document('$floor', '$x')).hashCode() == sortByCount(new Document('$floor', '$x')).hashCode()
+    }
+
+    def 'should test equals for FacetStage'() {
+        expect:
+        facet(
+                new Facet('Screen Sizes',
+                        unwind('$attributes'),
+                        match(eq('attributes.name', 'screen size')),
+                        group(null, sum('count', 1 ))),
+                new Facet('Manufacturer',
+                        match(eq('attributes.name', 'manufacturer')),
+                        group('$attributes.value', sum('count', 1)),
+                        sort(descending('count')),
+                        limit(5)))
+                .equals(facet(
+                new Facet('Screen Sizes',
+                        unwind('$attributes'),
+                        match(eq('attributes.name', 'screen size')),
+                        group(null, sum('count', 1 ))),
+                new Facet('Manufacturer',
+                        match(eq('attributes.name', 'manufacturer')),
+                        group('$attributes.value', sum('count', 1)),
+                        sort(descending('count')),
+                        limit(5))))
+    }
+
+    def 'should test hashCode for FacetStage'() {
+        expect:
+        facet(
+                new Facet('Screen Sizes',
+                        unwind('$attributes'),
+                        match(eq('attributes.name', 'screen size')),
+                        group(null, sum('count', 1 ))),
+                new Facet('Manufacturer',
+                        match(eq('attributes.name', 'manufacturer')),
+                        group('$attributes.value', sum('count', 1)),
+                        sort(descending('count')),
+                        limit(5))).hashCode() ==
+                facet(
+                new Facet('Screen Sizes',
+                        unwind('$attributes'),
+                        match(eq('attributes.name', 'screen size')),
+                        group(null, sum('count', 1 ))),
+                new Facet('Manufacturer',
+                        match(eq('attributes.name', 'manufacturer')),
+                        group('$attributes.value', sum('count', 1)),
+                        sort(descending('count')),
+                        limit(5))).hashCode()
+    }
+
+    def 'should test equals for AddFieldsStage'() {
+        expect:
+        addFields(new Field('newField', null)).equals(addFields(new Field('newField', null)))
+        addFields(new Field('newField', 'hello')).equals(addFields(new Field('newField', 'hello'))) 
+        addFields(new Field('this', '$$CURRENT')).equals(addFields(new Field('this', '$$CURRENT'))) 
+        addFields(new Field('myNewField', new Document('c', 3).append('d', 4)))
+                .equals(addFields(new Field('myNewField', new Document('c', 3).append('d', 4)))) 
+        addFields(new Field('alt3', new Document('$lt', asList('$a', 3))))
+                .equals(addFields(new Field('alt3', new Document('$lt', asList('$a', 3))))) 
+        addFields(new Field('b', 3), new Field('c', 5))
+                .equals(addFields(new Field('b', 3), new Field('c', 5))) 
+        addFields(asList(new Field('b', 3), new Field('c', 5)))
+                .equals(addFields(asList(new Field('b', 3), new Field('c', 5)))) 
+    }
+
+    def 'should test hashCode for AddFieldsStage'() {
+        expect:
+        addFields(new Field('newField', null)).hashCode() == addFields(new Field('newField', null)).hashCode()
+        addFields(new Field('newField', 'hello')).hashCode() == addFields(new Field('newField', 'hello')).hashCode()
+        addFields(new Field('this', '$$CURRENT')).hashCode() == addFields(new Field('this', '$$CURRENT')).hashCode()
+        addFields(new Field('myNewField', new Document('c', 3).append('d', 4))).hashCode() ==
+                addFields(new Field('myNewField', new Document('c', 3).append('d', 4))).hashCode()
+        addFields(new Field('alt3', new Document('$lt', asList('$a', 3)))).hashCode() ==
+                addFields(new Field('alt3', new Document('$lt', asList('$a', 3)))).hashCode()
+        addFields(new Field('b', 3), new Field('c', 5)).hashCode() ==
+                addFields(new Field('b', 3), new Field('c', 5)).hashCode()
+        addFields(asList(new Field('b', 3), new Field('c', 5))).hashCode() ==
+                addFields(asList(new Field('b', 3), new Field('c', 5))).hashCode()
+    }
+
+    def 'should test equals for ReplaceRootStage'() {
+        expect:
+        replaceRoot('$a1').equals(replaceRoot('$a1')) 
+        replaceRoot('$a1.b').equals(replaceRoot('$a1.b')) 
+        replaceRoot('$a1').equals(replaceRoot('$a1')) 
+    }
+
+    def 'should test hashCode for ReplaceRootStage'() {
+        expect:
+        replaceRoot('$a1').hashCode() == replaceRoot('$a1').hashCode()
+        replaceRoot('$a1.b').hashCode() == replaceRoot('$a1.b').hashCode()
+        replaceRoot('$a1').hashCode() == replaceRoot('$a1').hashCode()
+    }
+
+    def 'should test equals for OutStage'() {
+        expect:
+        out('authors').equals(out('authors')) 
+        out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION))
+                .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION))) 
+        out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS))
+        .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS))) 
+        out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS))
+        .equals(out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS))) 
+        out('authors', new AggregateOutStageOptions().databaseName('db1'))
+        .equals(out('authors', new AggregateOutStageOptions().databaseName('db1'))) 
+        out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1))))
+                .equals(out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1))))) 
+    }
+
+    def 'should test hashCode for OutStage'() {
+        expect:
+        out('authors').hashCode() == out('authors').hashCode()
+        out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION)).hashCode() ==
+                out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION)).hashCode()
+        out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS)).hashCode() ==
+                out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS)).hashCode()
+        out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS)).hashCode() ==
+                out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS)).hashCode()
+        out('authors', new AggregateOutStageOptions().databaseName('db1')).hashCode() ==
+                out('authors', new AggregateOutStageOptions().databaseName('db1')).hashCode()
+        out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1)))).hashCode() ==
+                out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1)))).hashCode()
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -543,21 +543,6 @@ class AggregatesSpecification extends Specification {
         group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }'))
                 .equals(group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')))
 
-        def groupDocument = parse('''{
-                            $group : {
-                                      _id : null,
-                                      sum: { $sum: { $multiply: [ "$price", "$quantity" ] } },
-                                      avg: { $avg: "$quantity" },
-                                      min: { $min: "$quantity" },
-                                      max: { $max: "$quantity" },
-                                      first: { $first: "$quantity" },
-                                      last: { $last: "$quantity" },
-                                      all: { $push: "$quantity" },
-                                      unique: { $addToSet: "$quantity" },
-                                      stdDevPop: { $stdDevPop: "$quantity" },
-                                      stdDevSamp: { $stdDevSamp: "$quantity" }
-                                     }
-                                  }''')
         group(null,
                 sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
                 avg('avg', '$quantity'),
@@ -591,21 +576,6 @@ class AggregatesSpecification extends Specification {
         group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')).hashCode() ==
                 group(parse('{ month: { $month: "$date" }, day: { $dayOfMonth: "$date" }, year: { $year: "$date" } }')).hashCode()
 
-        def groupDocument = parse('''{
-                            $group : {
-                                      _id : null,
-                                      sum: { $sum: { $multiply: [ "$price", "$quantity" ] } },
-                                      avg: { $avg: "$quantity" },
-                                      min: { $min: "$quantity" },
-                                      max: { $max: "$quantity" },
-                                      first: { $first: "$quantity" },
-                                      last: { $last: "$quantity" },
-                                      all: { $push: "$quantity" },
-                                      unique: { $addToSet: "$quantity" },
-                                      stdDevPop: { $stdDevPop: "$quantity" },
-                                      stdDevSamp: { $stdDevSamp: "$quantity" }
-                                     }
-                                  }''')
         group(null,
                 sum('sum', parse('{ $multiply: [ "$price", "$quantity" ] }')),
                 avg('avg', '$quantity'),
@@ -694,16 +664,16 @@ class AggregatesSpecification extends Specification {
     def 'should test equals for AddFieldsStage'() {
         expect:
         addFields(new Field('newField', null)).equals(addFields(new Field('newField', null)))
-        addFields(new Field('newField', 'hello')).equals(addFields(new Field('newField', 'hello'))) 
-        addFields(new Field('this', '$$CURRENT')).equals(addFields(new Field('this', '$$CURRENT'))) 
+        addFields(new Field('newField', 'hello')).equals(addFields(new Field('newField', 'hello')))
+        addFields(new Field('this', '$$CURRENT')).equals(addFields(new Field('this', '$$CURRENT')))
         addFields(new Field('myNewField', new Document('c', 3).append('d', 4)))
-                .equals(addFields(new Field('myNewField', new Document('c', 3).append('d', 4)))) 
+                .equals(addFields(new Field('myNewField', new Document('c', 3).append('d', 4))))
         addFields(new Field('alt3', new Document('$lt', asList('$a', 3))))
-                .equals(addFields(new Field('alt3', new Document('$lt', asList('$a', 3))))) 
+                .equals(addFields(new Field('alt3', new Document('$lt', asList('$a', 3)))))
         addFields(new Field('b', 3), new Field('c', 5))
-                .equals(addFields(new Field('b', 3), new Field('c', 5))) 
+                .equals(addFields(new Field('b', 3), new Field('c', 5)))
         addFields(asList(new Field('b', 3), new Field('c', 5)))
-                .equals(addFields(asList(new Field('b', 3), new Field('c', 5)))) 
+                .equals(addFields(asList(new Field('b', 3), new Field('c', 5))))
     }
 
     def 'should test hashCode for AddFieldsStage'() {
@@ -723,9 +693,9 @@ class AggregatesSpecification extends Specification {
 
     def 'should test equals for ReplaceRootStage'() {
         expect:
-        replaceRoot('$a1').equals(replaceRoot('$a1')) 
-        replaceRoot('$a1.b').equals(replaceRoot('$a1.b')) 
-        replaceRoot('$a1').equals(replaceRoot('$a1')) 
+        replaceRoot('$a1').equals(replaceRoot('$a1'))
+        replaceRoot('$a1.b').equals(replaceRoot('$a1.b'))
+        replaceRoot('$a1').equals(replaceRoot('$a1'))
     }
 
     def 'should test hashCode for ReplaceRootStage'() {
@@ -737,17 +707,17 @@ class AggregatesSpecification extends Specification {
 
     def 'should test equals for OutStage'() {
         expect:
-        out('authors').equals(out('authors')) 
+        out('authors').equals(out('authors'))
         out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION))
-                .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION))) 
+                .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_COLLECTION)))
         out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS))
-        .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS))) 
+        .equals(out('authors', new AggregateOutStageOptions().mode(REPLACE_DOCUMENTS)))
         out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS))
-        .equals(out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS))) 
+        .equals(out('authors', new AggregateOutStageOptions().mode(INSERT_DOCUMENTS)))
         out('authors', new AggregateOutStageOptions().databaseName('db1'))
-        .equals(out('authors', new AggregateOutStageOptions().databaseName('db1'))) 
+        .equals(out('authors', new AggregateOutStageOptions().databaseName('db1')))
         out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1))))
-                .equals(out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1))))) 
+                .equals(out('authors', new AggregateOutStageOptions().uniqueKey(new BsonDocument('x', new BsonInt32(1)))))
     }
 
     def 'should test hashCode for OutStage'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -83,8 +83,6 @@ class FiltersSpecification extends Specification {
         toBson(eq('x', 1)) == parse('{x : 1}')
         toBson(eq('x', null)) == parse('{x : null}')
         toBson(eq(1)) == parse('{_id : 1}')
-
-        eq('x', 1).equals(eq('x', 1))
     }
 
     def 'should render $ne'() {
@@ -695,5 +693,153 @@ class FiltersSpecification extends Specification {
 
     def toBson(Bson bson) {
         bson.toBsonDocument(BsonDocument, registry)
+    }
+
+    def 'should test equals for SimpleFilter'() {
+        expect:
+        regex('x', 'acme.*corp').equals(regex('x', 'acme.*corp'))
+    }
+
+    def 'should test hashCode for SimpleFilter'() {
+        expect:
+        regex('x', 'acme.*corp').hashCode() == regex('x', 'acme.*corp').hashCode()
+    }
+
+    def 'should test equals for OperatorFilter'() {
+        expect:
+        ne('x', 1).equals(ne('x', 1))
+        exists('x').equals(exists('x', true))
+        exists('x', false).equals(exists('x', false))
+        type('a', BsonType.ARRAY).equals(type('a', BsonType.ARRAY))
+        !type('a', 'number').equals(type('a', BsonType.ARRAY))
+    }
+
+    def 'should test hashCode for OperatorFilter'() {
+        expect:
+        ne('x', 1).hashCode() == ne('x', 1).hashCode()
+        exists('x').hashCode() == exists('x', true).hashCode()
+        exists('x', false).hashCode() == exists('x', false).hashCode()
+        type('a', BsonType.ARRAY).hashCode() == type('a', BsonType.ARRAY).hashCode()
+        type('a', 'number').hashCode() != type('a', BsonType.ARRAY).hashCode()
+    }
+
+    def 'should test equals for AndFilter'() {
+        expect:
+        and([]).equals(and())
+        and([eq('x', 1), eq('y', 2)])
+                .equals(and(eq('x', 1), eq('y', 2)))
+    }
+
+    def 'should test hashCode for AndFilter'() {
+        expect:
+        and([]).hashCode() == and().hashCode()
+        and([eq('x', 1), eq('y', 2)]).hashCode() ==
+                and(eq('x', 1), eq('y', 2)).hashCode()
+    }
+
+    def 'should test equals for OrNorFilter'() {
+        expect:
+        or([]).equals(or())
+        nor(eq('x', 1), eq('x', 2)).equals(nor(eq('x', 1), eq('x', 2)))
+        !nor(eq('x', 1), eq('x', 2)).equals(or(eq('x', 1), eq('x', 2)))
+    }
+
+    def 'should test hashCode for OrNorFilter'() {
+        expect:
+        or([]).hashCode() == or().hashCode()
+        nor(eq('x', 1), eq('x', 2)).hashCode() == nor(eq('x', 1), eq('x', 2)).hashCode()
+        nor(eq('x', 1), eq('x', 2)).hashCode() != or(eq('x', 1), eq('x', 2)).hashCode()
+    }
+
+    def 'should test equals for IterableOperatorFilter'() {
+        expect:
+        Filters.in('a', [1, 2, 3]).equals(Filters.in('a', 1, 2, 3))
+        !nin('a', [1, 2, 3]).equals(nin('a', 1, 2))
+        !all('a', [1, 2, 3]).equals(nin('a', 1, 2, 3))
+        all('a', []).equals(all('a'))
+    }
+
+    def 'should test hashCode for IterableOperatorFilter'() {
+        expect:
+        Filters.in('a', [1, 2, 3]).hashCode() == Filters.in('a', 1, 2, 3).hashCode()
+        nin('a', [1, 2, 3]).hashCode() != nin('a', 1, 2).hashCode()
+        all('a', [1, 2, 3]).hashCode() != nin('a', 1, 2, 3).hashCode()
+        all('a', []).hashCode() == all('a').hashCode()
+    }
+
+    def 'should test equals for SimpleEncodingFilter'() {
+        expect:
+        eq('x', 1).equals(eq('x', 1))
+        !eq('x', 1).equals(ne('x', 1))
+        !eq('x', 1).equals(eq('x', 2))
+        !eq('y', 1).equals(eq('x', 1))
+        !eq('x', 1).equals(parse('{x : 1}'))
+        expr(new BsonDocument('$gt', new BsonArray([new BsonString('$spent'), new BsonString('$budget')])))
+                .equals(expr(new BsonDocument('$gt', new BsonArray([new BsonString('$spent'), new BsonString('$budget')]))))
+    }
+
+    def 'should test hashCode for SimpleEncodingFilter'() {
+        expect:
+        eq('x', 1).hashCode() == eq('x', 1).hashCode()
+        eq('x', 1).hashCode() != ne('x', 1).hashCode()
+        eq('x', 1).hashCode() != eq('x', 2).hashCode()
+        eq('y', 1).hashCode() != eq('x', 1).hashCode()
+        eq('x', 1).hashCode() != parse('{x : 1}').hashCode()
+        expr(new BsonDocument('$gt', new BsonArray([new BsonString('$spent'), new BsonString('$budget')]))).hashCode() ==
+                expr(new BsonDocument('$gt', new BsonArray([new BsonString('$spent'), new BsonString('$budget')]))).hashCode()
+    }
+
+    def 'should test equals for NotFilter'() {
+        expect:
+        not(eq('x', 1)).equals(not(eq('x', 1)))
+    }
+
+    def 'should test hashCode for NotFilter'() {
+        expect:
+        not(eq('x', 1)).hashCode() == not(eq('x', 1)).hashCode()
+    }
+
+    def 'should test equals for GeometryOperatorFilter'() {
+        def polygon = new Polygon([new Position([40.0d, 18.0d]),
+                                   new Position([40.0d, 19.0d]),
+                                   new Position([41.0d, 19.0d]),
+                                   new Position([40.0d, 18.0d])])
+        expect:
+        geoWithin('loc', polygon).equals(geoWithin('loc', polygon))
+        !geoWithinBox('loc', 1d, 2d, 3d, 4d)
+                .equals(geoWithinBox('loc', 1d, 2d, 3d, 5d))
+
+        geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]])
+                .equals(geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]))
+
+    }
+
+    def 'should test hashCode for GeometryOperatorFilter'() {
+        def polygon = new Polygon([new Position([40.0d, 18.0d]),
+                                   new Position([40.0d, 19.0d]),
+                                   new Position([41.0d, 19.0d]),
+                                   new Position([40.0d, 18.0d])])
+        expect:
+        geoWithin('loc', polygon).hashCode() == geoWithin('loc', polygon).hashCode()
+        geoWithinBox('loc', 1d, 2d, 3d, 4d).hashCode() !=
+                geoWithinBox('loc', 1d, 2d, 3d, 5d).hashCode()
+
+        geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]).hashCode() ==
+                geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]).hashCode()
+
+    }
+
+    def 'should test equals for TextFilter'() {
+        expect:
+        text('mongoDB for GIANT ideas').equals(text('mongoDB for GIANT ideas'))
+        text('mongoDB for GIANT ideas', 'english')
+                .equals(text('mongoDB for GIANT ideas', new TextSearchOptions().language('english')))
+    }
+
+    def 'should test hashCode for TextFilter'() {
+        expect:
+        text('mongoDB for GIANT ideas').hashCode() == text('mongoDB for GIANT ideas').hashCode()
+        text('mongoDB for GIANT ideas', 'english').hashCode() ==
+                text('mongoDB for GIANT ideas', new TextSearchOptions().language('english')).hashCode()
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -83,6 +83,8 @@ class FiltersSpecification extends Specification {
         toBson(eq('x', 1)) == parse('{x : 1}')
         toBson(eq('x', null)) == parse('{x : null}')
         toBson(eq(1)) == parse('{_id : 1}')
+
+        eq('x', 1).equals(eq('x', 1))
     }
 
     def 'should render $ne'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -811,7 +811,6 @@ class FiltersSpecification extends Specification {
 
         geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]])
                 .equals(geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]))
-
     }
 
     def 'should test hashCode for GeometryOperatorFilter'() {
@@ -826,7 +825,6 @@ class FiltersSpecification extends Specification {
 
         geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]).hashCode() ==
                 geoWithinPolygon('loc', [[0d, 0d], [3d, 6d], [6d, 0d]]).hashCode()
-
     }
 
     def 'should test equals for TextFilter'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/IndexesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/IndexesSpecification.groovy
@@ -89,4 +89,28 @@ class IndexesSpecification extends Specification {
     def toBson(Bson bson) {
         bson.toBsonDocument(BsonDocument, registry)
     }
+
+    def 'should test equals on CompoundIndex'() {
+        expect:
+        compoundIndex([ascending('x'), descending('y')])
+                .equals(compoundIndex([ascending('x'), descending('y')]))
+        compoundIndex(ascending('x'), descending('y'))
+                .equals(compoundIndex(ascending('x'), descending('y')))
+        compoundIndex(ascending('x'), descending('y'), descending('x'))
+                .equals(compoundIndex(ascending('x'), descending('y'), descending('x')))
+        compoundIndex(ascending('x', 'y'), descending('a', 'b'))
+                .equals(compoundIndex(ascending('x', 'y'), descending('a', 'b')))
+    }
+
+    def 'should test hashCode on CompoundIndex'() {
+        expect:
+        compoundIndex([ascending('x'), descending('y')]).hashCode() ==
+                compoundIndex([ascending('x'), descending('y')]).hashCode()
+        compoundIndex(ascending('x'), descending('y')).hashCode() ==
+                compoundIndex(ascending('x'), descending('y')).hashCode()
+        compoundIndex(ascending('x'), descending('y'), descending('x')).hashCode() ==
+                compoundIndex(ascending('x'), descending('y'), descending('x')).hashCode()
+        compoundIndex(ascending('x', 'y'), descending('a', 'b')).hashCode() ==
+                compoundIndex(ascending('x', 'y'), descending('a', 'b')).hashCode()
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/SortsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/SortsSpecification.groovy
@@ -75,4 +75,28 @@ class SortsSpecification extends Specification {
     def toBson(Bson bson) {
         bson.toBsonDocument(BsonDocument, registry)
     }
+
+    def 'should test equals for CompoundSort'() {
+        expect:
+        orderBy([ascending('x'), descending('y')])
+                .equals(orderBy([ascending('x'), descending('y')]))
+        orderBy(ascending('x'), descending('y'))
+                .equals(orderBy(ascending('x'), descending('y')))
+        orderBy(ascending('x'), descending('y'), descending('x'))
+                .equals(orderBy(ascending('x'), descending('y'), descending('x')))
+        orderBy(ascending('x', 'y'), descending('a', 'b'))
+                .equals(orderBy(ascending('x', 'y'), descending('a', 'b')))
+    }
+
+    def 'should test hashCode for CompoundSort'() {
+        expect:
+        orderBy([ascending('x'), descending('y')]).hashCode() ==
+                orderBy([ascending('x'), descending('y')]).hashCode()
+        orderBy(ascending('x'), descending('y')).hashCode() ==
+                orderBy(ascending('x'), descending('y')).hashCode()
+        orderBy(ascending('x'), descending('y'), descending('x')).hashCode() ==
+                orderBy(ascending('x'), descending('y'), descending('x')).hashCode()
+        orderBy(ascending('x', 'y'), descending('a', 'b')).hashCode() ==
+                orderBy(ascending('x', 'y'), descending('a', 'b')).hashCode()
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/UpdatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/UpdatesSpecification.groovy
@@ -215,4 +215,146 @@ class UpdatesSpecification extends Specification {
         bson.toBsonDocument(BsonDocument, registry)
     }
 
+    def 'should test equals for SimpleBsonKeyValue'() {
+        expect:
+        setOnInsert('x', 1).equals(setOnInsert('x', 1))
+        setOnInsert('x', null).equals(setOnInsert('x', null))
+        setOnInsert(parse('{ a : 1, b: "two"}')).equals(setOnInsert(parse('{ a : 1, b: "two"}')))
+    }
+
+    def 'should test hashCode for SimpleBsonKeyValue'() {
+        expect:
+        setOnInsert('x', 1).hashCode() == setOnInsert('x', 1).hashCode()
+        setOnInsert('x', null).hashCode() == setOnInsert('x', null).hashCode()
+        setOnInsert(parse('{ a : 1, b: "two"}')).hashCode() == setOnInsert(parse('{ a : 1, b: "two"}')).hashCode()
+    }
+
+    def 'should test equals for SimpleUpdate'() {
+        expect:
+        setOnInsert('x', 1).equals(setOnInsert('x', 1))
+        setOnInsert('x', null).equals(setOnInsert('x', null))
+        setOnInsert(parse('{ a : 1, b: "two"}')).equals(setOnInsert(parse('{ a : 1, b: "two"}')))
+        rename('x', 'y').equals(rename('x', 'y'))
+        inc('x', 1).equals(inc('x', 1))
+        inc('x', 5L).equals(inc('x', 5L))
+        inc('x', 3.4d).equals(inc('x', 3.4d))
+        mul('x', 1).equals(mul('x', 1))
+        mul('x', 5L).equals(mul('x', 5L))
+        mul('x', 3.4d).equals(mul('x', 3.4d))
+        min('x', 42).equals(min('x', 42))
+        max('x', 42).equals(max('x', 42))
+        currentDate('x').equals(currentDate('x'))
+        currentTimestamp('x').equals(currentTimestamp('x'))
+        addToSet('x', 1).equals(addToSet('x', 1))
+        addEachToSet('x', [1, 2, 3]).equals(addEachToSet('x', [1, 2, 3]))
+        push('x', 1).equals(push('x', 1))
+        pull('x', 1).equals(pull('x', 1))
+        popFirst('x').equals(popFirst('x'))
+        popLast('x').equals(popLast('x'))
+    }
+
+    def 'should test hashCode for SimpleUpdate'() {
+        expect:
+        setOnInsert('x', 1).hashCode() == setOnInsert('x', 1).hashCode()
+        setOnInsert('x', null).hashCode() == setOnInsert('x', null).hashCode()
+        setOnInsert(parse('{ a : 1, b: "two"}')).hashCode() == setOnInsert(parse('{ a : 1, b: "two"}')).hashCode()
+        rename('x', 'y').hashCode() == rename('x', 'y').hashCode()
+        inc('x', 1).hashCode() == inc('x', 1).hashCode()
+        inc('x', 5L).hashCode() == inc('x', 5L).hashCode()
+        inc('x', 3.4d).hashCode() == inc('x', 3.4d).hashCode()
+        mul('x', 1).hashCode() == mul('x', 1).hashCode()
+        mul('x', 5L).hashCode() == mul('x', 5L).hashCode()
+        mul('x', 3.4d).hashCode() == mul('x', 3.4d).hashCode()
+        min('x', 42).hashCode() == min('x', 42).hashCode()
+        max('x', 42).hashCode() == max('x', 42).hashCode()
+        currentDate('x').hashCode() == currentDate('x').hashCode()
+        currentTimestamp('x').hashCode() == currentTimestamp('x').hashCode()
+        addToSet('x', 1).hashCode() == addToSet('x', 1).hashCode()
+        addEachToSet('x', [1, 2, 3]).hashCode() == addEachToSet('x', [1, 2, 3]).hashCode()
+        push('x', 1).hashCode() == push('x', 1).hashCode()
+        pull('x', 1).hashCode() == pull('x', 1).hashCode()
+        popFirst('x').hashCode() == popFirst('x').hashCode()
+        popLast('x').hashCode() == popLast('x').hashCode()
+    }
+
+    def 'should test equals for WithEachUpdate'() {
+        expect:
+        addEachToSet('x', [1, 2, 3]).equals(addEachToSet('x', [1, 2, 3]))
+    }
+
+    def 'should test hashCode for WithEachUpdate'() {
+        expect:
+        addEachToSet('x', [1, 2, 3]).hashCode() == addEachToSet('x', [1, 2, 3]).hashCode()
+    }
+
+    def 'should test equals for PushUpdate'() {
+        expect:
+        pushEach('x', [1, 2, 3], new PushOptions()).equals(pushEach('x', [1, 2, 3], new PushOptions()))
+        pushEach('x', [parse('{score : 89}'), parse('{score : 65}')],
+                new PushOptions().position(0).slice(3).sortDocument(parse('{score : -1}')))
+        .equals(pushEach('x', [parse('{score : 89}'), parse('{score : 65}')],
+                new PushOptions().position(0).slice(3).sortDocument(parse('{score : -1}'))))
+
+        pushEach('x', [89, 65],
+                new PushOptions().position(0).slice(3).sort(-1))
+        .equals(pushEach('x', [89, 65],
+                new PushOptions().position(0).slice(3).sort(-1)))
+    }
+
+    def 'should test hashCode for PushUpdate'() {
+        expect:
+        pushEach('x', [1, 2, 3], new PushOptions()).hashCode() == pushEach('x', [1, 2, 3], new PushOptions()).hashCode()
+        pushEach('x', [parse('{score : 89}'), parse('{score : 65}')],
+                new PushOptions().position(0).slice(3).sortDocument(parse('{score : -1}'))).hashCode() ==
+                pushEach('x', [parse('{score : 89}'), parse('{score : 65}')],
+                new PushOptions().position(0).slice(3).sortDocument(parse('{score : -1}'))).hashCode()
+
+        pushEach('x', [89, 65],
+                new PushOptions().position(0).slice(3).sort(-1)).hashCode() ==
+                pushEach('x', [89, 65], new PushOptions().position(0).slice(3).sort(-1)).hashCode()
+    }
+
+    def 'should test equals for PullAllUpdate'() {
+        expect:
+        pullAll('x', []).equals(pullAll('x', []))
+        pullAll('x', [1, 2, 3]).equals(pullAll('x', [1, 2, 3]))
+    }
+
+    def 'should test hashCode for PullAllUpdate'() {
+        expect:
+        pullAll('x', []).hashCode() == pullAll('x', []).hashCode()
+        pullAll('x', [1, 2, 3]).hashCode() == pullAll('x', [1, 2, 3]).hashCode()
+    }
+
+    def 'should test equals for CompositeUpdate'() {
+        expect:
+        combine(set('x', 1)).equals(combine(set('x', 1)))
+        combine(set('x', 1), set('y', 2)).equals(combine(set('x', 1), set('y', 2)))
+        combine(set('x', 1), set('x', 2)).equals(combine(set('x', 1), set('x', 2)))
+        combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4))
+                .equals(combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4)))
+
+        combine(combine(set('x', 1))).equals(combine(combine(set('x', 1))))
+        combine(combine(set('x', 1), set('y', 2))).equals(combine(combine(set('x', 1), set('y', 2))))
+        combine(combine(set('x', 1), set('x', 2))).equals(combine(combine(set('x', 1), set('x', 2))))
+
+        combine(combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4)))
+                .equals(combine(combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4))))
+    }
+
+    def 'should test hashCode for CompositeUpdate'() {
+        expect:
+        combine(set('x', 1)).hashCode() == combine(set('x', 1)).hashCode()
+        combine(set('x', 1), set('y', 2)).hashCode() == combine(set('x', 1), set('y', 2)).hashCode()
+        combine(set('x', 1), set('x', 2)).equals(combine(set('x', 1), set('x', 2)))
+        combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4)).hashCode() ==
+                combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4)).hashCode()
+
+        combine(combine(set('x', 1))).hashCode() == combine(combine(set('x', 1))).hashCode()
+        combine(combine(set('x', 1), set('y', 2))).hashCode() == combine(combine(set('x', 1), set('y', 2))).hashCode()
+        combine(combine(set('x', 1), set('x', 2))).hashCode() == combine(combine(set('x', 1), set('x', 2))).hashCode()
+
+        combine(combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4))).hashCode() ==
+                combine(combine(set('x', 1), inc('z', 3), set('y', 2), inc('a', 4))).hashCode()
+    }
 }


### PR DESCRIPTION
Implemented `equals` and `hashCode` methods in classes implementing `Bson` - Aggregates, Facet, Filters, Indexes, Sorts and Updates. A few of the Options classes also needed `equals` and `hashCode` methods so that instances having options fields would be correctly compared.

Evergreen patch: https://evergreen.mongodb.com/version/5c5ce1be57e85a530ca96d83