### PR TITLE
JAVA-3254: update tests for Evergreen

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
@@ -89,7 +89,7 @@ public class CrudTest {
 
         collectionHelper = new CollectionHelper<Document>(new DocumentCodec(), new MongoNamespace(databaseName, collectionName));
         collectionHelper.killAllSessions();
-        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.MAJORITY);
+        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.ACKNOWLEDGED);
 
         com.mongodb.MongoClientSettings.Builder builder = getMongoClientBuilderFromConnectionString()
                 .addCommandListener(commandListener);

--- a/driver-core/src/test/functional/com/mongodb/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindAndUpdateOperationSpecification.groovy
@@ -322,6 +322,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
+    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
     def 'should support bypassDocumentValidation'() {
         given:
         def namespace = new MongoNamespace(getDatabaseName(), 'collectionOut')

--- a/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
@@ -91,7 +91,7 @@ public class LegacyCrudTest {
         collectionHelper = new CollectionHelper<Document>(new DocumentCodec(), new MongoNamespace(databaseName, collectionName));
 
         collectionHelper.killAllSessions();
-        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.MAJORITY);
+        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.ACKNOWLEDGED);
 
         MongoClientSettings settings = MongoClientSettings.builder(getMongoClientSettings())
                 .addCommandListener(commandListener)

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
@@ -91,7 +91,7 @@ public class CrudTest {
         collectionHelper = new CollectionHelper<Document>(new DocumentCodec(), new MongoNamespace(databaseName, collectionName));
 
         collectionHelper.killAllSessions();
-        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.MAJORITY);
+        collectionHelper.create(collectionName, new CreateCollectionOptions(), WriteConcern.ACKNOWLEDGED);
 
         MongoClientSettings settings = MongoClientSettings.builder(getMongoClientSettings())
                 .addCommandListener(commandListener)


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d275f493627e010a5288d72
Evergreen tests were failing in server versions 2.6 and 3.0 when I merged my changes for JAVA-3254 into master, and some intermittent errors appeared in the CRUD tests from the write concern. 