### PR TITLE
JAVA-3293: ChangeStream spec Resumable Error definition is too broad

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursorHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursorHelper.java
@@ -22,12 +22,14 @@ import com.mongodb.MongoException;
 import com.mongodb.MongoNotPrimaryException;
 import com.mongodb.MongoSocketException;
 
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 
 final class ChangeStreamBatchCursorHelper {
     private static final List<Integer> UNRETRYABLE_SERVER_ERROR_CODES = asList(136, 237, 280, 11601);
+    private static final List<String> NONRESUMABLE_CHANGE_STREAM_ERROR_LABELS = asList("NonResumableChangeStreamError");
 
     static boolean isRetryableError(final Throwable t) {
         if (!(t instanceof MongoException) || t instanceof MongoChangeStreamException) {
@@ -36,7 +38,8 @@ final class ChangeStreamBatchCursorHelper {
                 || t instanceof MongoSocketException) {
             return true;
         } else {
-            return !UNRETRYABLE_SERVER_ERROR_CODES.contains(((MongoException) t).getCode());
+            return !UNRETRYABLE_SERVER_ERROR_CODES.contains(((MongoException) t).getCode())
+                    && Collections.disjoint(NONRESUMABLE_CHANGE_STREAM_ERROR_LABELS, ((MongoException) t).getErrorLabels());
         }
     }
 

--- a/driver-core/src/test/resources/change-streams/change-streams-errors.json
+++ b/driver-core/src/test/resources/change-streams/change-streams-errors.json
@@ -54,9 +54,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 },
                 {
                   "$unsupported": "foo"
@@ -71,6 +69,43 @@
       "result": {
         "error": {
           "code": 40324
+        }
+      }
+    },
+    {
+      "description": "Change Stream should error when _id is projected out",
+      "minServerVersion": "4.1.11",
+      "target": "collection",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ],
+      "changeStreamPipeline": [
+        {
+          "$project": {
+            "_id": 0
+          }
+        }
+      ],
+      "changeStreamOptions": {},
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        }
+      ],
+      "result": {
+        "error": {
+          "code": 280,
+          "errorLabels": [
+            "NonResumableChangeStreamError"
+          ]
         }
       }
     }


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d35ae3730