### PR TITLE
JAVA-3353: Avoid reordering of _id field in Document and BasicDBObject

### DIFF
--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -436,7 +436,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      */
     public String toJson(final JsonWriterSettings writerSettings, final Encoder<Document> encoder) {
         JsonWriter writer = new JsonWriter(new StringWriter(), writerSettings);
-        encoder.encode(writer, this, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+        encoder.encode(writer, this, EncoderContext.builder().build());
         return writer.getWriter().toString();
     }
 

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -79,6 +79,16 @@ public class DocumentTest {
                      document);
     }
 
+    // Test to ensure that toJson does not reorder _id field
+    @Test
+    public void toJsonShouldNotReorderIdField() {
+        // given
+        Document d = new Document().append("x", 1)
+                .append("y", Collections.singletonList("one"))
+                .append("_id", "1");
+        assertEquals(new DocumentCodec().decode(new JsonReader(d.toJson()), DecoderContext.builder().build()), d);
+    }
+
     // Test in Java to make sure none of the casts result in compiler warnings or class cast exceptions
     @Test
     public void shouldGetWithDefaultValue() {

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -86,7 +86,7 @@ public class DocumentTest {
         Document d = new Document().append("x", 1)
                 .append("y", Collections.singletonList("one"))
                 .append("_id", "1");
-        assertEquals(new DocumentCodec().decode(new JsonReader(d.toJson()), DecoderContext.builder().build()), d);
+        assertEquals("{\"x\": 1, \"y\": [\"one\"], \"_id\": \"1\"}", d.toJson());
     }
 
     // Test in Java to make sure none of the casts result in compiler warnings or class cast exceptions

--- a/driver-core/src/main/com/mongodb/BasicDBObject.java
+++ b/driver-core/src/main/com/mongodb/BasicDBObject.java
@@ -191,7 +191,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      */
     public String toJson(final JsonWriterSettings writerSettings, final Encoder<BasicDBObject> encoder) {
         JsonWriter writer = new JsonWriter(new StringWriter(), writerSettings);
-        encoder.encode(writer, this, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+        encoder.encode(writer, this, EncoderContext.builder().build());
         return writer.getWriter().toString();
     }
 

--- a/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
+++ b/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
@@ -60,19 +60,19 @@ public class BasicDBObjectTest {
 
     @Test
     public void testToJson() {
-        BasicDBObject document = BasicDBObject.parse("{ '_id' : { '$oid' : '000000000000000000000000' }, 'int' : 1, 'string' : 'abc', "
+        BasicDBObject document = BasicDBObject.parse("{ 'int' : 1, 'string' : 'abc', '_id' : { '$oid' : '000000000000000000000000' }, "
                 + "'dbRef' : { $ref: 'collection', $id: { $oid: '01234567890123456789abcd' }, $db: 'db' } }");
 
-        assertEquals("{\"_id\": {\"$oid\": \"000000000000000000000000\"}, \"int\": 1, \"string\": \"abc\", "
+        assertEquals("{\"int\": 1, \"string\": \"abc\", \"_id\": {\"$oid\": \"000000000000000000000000\"}, "
                 + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"01234567890123456789abcd\"}, \"$db\": \"db\"}}",
                 document.toJson());
-        assertEquals("{\"_id\": ObjectId(\"000000000000000000000000\"), \"int\": 1, \"string\": \"abc\", "
+        assertEquals("{\"int\": 1, \"string\": \"abc\", \"_id\": ObjectId(\"000000000000000000000000\"), "
                 + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": ObjectId(\"01234567890123456789abcd\"), \"$db\": \"db\"}}",
                 document.toJson(JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build()));
-        assertEquals("{\"_id\": {\"$oid\": \"000000000000000000000000\"}, \"int\": 1, \"string\": \"abc\", "
+        assertEquals("{\"int\": 1, \"string\": \"abc\", \"_id\": {\"$oid\": \"000000000000000000000000\"}, "
                 + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"01234567890123456789abcd\"}, \"$db\": \"db\"}}",
                 document.toJson(DECODER));
-        assertEquals("{\"_id\": ObjectId(\"000000000000000000000000\"), \"int\": 1, \"string\": \"abc\", "
+        assertEquals("{\"int\": 1, \"string\": \"abc\", \"_id\": ObjectId(\"000000000000000000000000\"), "
                 + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": ObjectId(\"01234567890123456789abcd\"), \"$db\": \"db\"}}",
                 document.toJson(JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build(), DECODER));
     }


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d386c561e2d171348bc23e7