### PR TITLE
JAVA-3163: Re-enable changestream test for sharded clusters

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -54,7 +54,6 @@ import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
-import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
@@ -404,7 +403,6 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    @IgnoreIf({ isSharded() })
     def 'should throw if the _id field is projected out'() {
         given:
         def helper = getHelper()


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d38777ca4cf471187186385