### PR TITLE
JAVA-3361: Fix compiler warnings in OperationHelper.java

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -56,7 +56,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation that executes an aggregation that writes its results to a collection (which is what makes this a write operation rather than
@@ -378,7 +378,7 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -56,6 +56,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation that executes an aggregation that writes its results to a collection (which is what makes this a write operation rather than
@@ -377,7 +378,7 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -33,7 +33,7 @@ import java.util.List;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.operation.ChangeStreamBatchCursorHelper.isRetryableError;
 import static com.mongodb.operation.OperationHelper.LOGGER;
-import static com.mongodb.operation.OperationHelper.withConnection;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
 
 final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private final AsyncReadBinding binding;
@@ -170,7 +170,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
     }
 
     private void retryOperation(final AsyncBlock asyncBlock, final SingleResultCallback<List<RawBsonDocument>> callback) {
-        withConnection(binding, new AsyncCallableWithSource() {
+        withReadConnectionAsync(binding, new AsyncCallableWithSource() {
             @Override
             public void call(final AsyncConnectionSource source, final Throwable t) {
                 if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -33,7 +33,7 @@ import java.util.List;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.operation.ChangeStreamBatchCursorHelper.isRetryableError;
 import static com.mongodb.operation.OperationHelper.LOGGER;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 
 final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private final AsyncReadBinding binding;
@@ -170,7 +170,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
     }
 
     private void retryOperation(final AsyncBlock asyncBlock, final SingleResultCallback<List<RawBsonDocument>> callback) {
-        withReadConnectionAsync(binding, new AsyncCallableWithSource() {
+        withAsyncReadConnection(binding, new AsyncCallableWithSource() {
             @Override
             public void call(final AsyncConnectionSource source, final Throwable t) {
                 if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.operation.ChangeStreamBatchCursorHelper.isRetryableError;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 
 final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T> {
     private final ReadBinding binding;
@@ -167,7 +167,7 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
             }
             wrapped.close();
 
-            withConnectionSource(binding, new CallableWithSource<Void>() {
+            withReadConnectionSource(binding, new CallableWithSource<Void>() {
                 @Override
                 public Void call(final ConnectionSource source) {
                     changeStreamOperation.setChangeStreamOptionsForResume(resumeToken, source.getServerDescription().getMaxWireVersion());

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -47,8 +47,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 
 /**
  * An operation that executes an {@code $changeStream} aggregation.
@@ -333,7 +333,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
+        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source) {
                 AggregateResponseBatchCursor<RawBsonDocument> cursor =
@@ -355,7 +355,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
                 } else {
                     final AsyncAggregateResponseBatchCursor<RawBsonDocument> cursor =
                             (AsyncAggregateResponseBatchCursor<RawBsonDocument>) result;
-                    withConnection(binding, new AsyncCallableWithSource() {
+                    withReadConnectionAsync(binding, new AsyncCallableWithSource() {
                         @Override
                         public void call(final AsyncConnectionSource source, final Throwable t) {
                             if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 
 /**
@@ -355,7 +355,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
                 } else {
                     final AsyncAggregateResponseBatchCursor<RawBsonDocument> cursor =
                             (AsyncAggregateResponseBatchCursor<RawBsonDocument>) result;
-                    withReadConnectionAsync(binding, new AsyncCallableWithSource() {
+                    withAsyncReadConnection(binding, new AsyncCallableWithSource() {
                         @Override
                         public void call(final AsyncConnectionSource source, final Throwable t) {
                             if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -56,7 +56,8 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.canRetryRead;
 import static com.mongodb.operation.OperationHelper.canRetryWrite;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.operation.OperationHelper.withReleasableConnection;
 import static java.lang.String.format;
@@ -404,7 +405,7 @@ final class CommandOperationHelper {
                                            final boolean retryReads,
                                            final SingleResultCallback<T> originalCallback) {
         final SingleResultCallback<T> errorHandlingCallback = errorHandlingCallback(originalCallback, LOGGER);
-        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
@@ -497,7 +498,7 @@ final class CommandOperationHelper {
             }
 
             private void retryableCommand(final Throwable originalError) {
-                withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+                withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                         if (t != null) {
@@ -837,7 +838,7 @@ final class CommandOperationHelper {
             private void retryableCommand(final Throwable originalError) {
                 final BsonDocument retryCommand = retryCommandModifier.apply(command);
                 logRetryExecute(retryCommand.getFirstKey(), originalError);
-                OperationHelper.withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+                withAsyncConnection(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                         if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -56,8 +56,8 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.canRetryRead;
 import static com.mongodb.operation.OperationHelper.canRetryWrite;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.operation.OperationHelper.withReleasableConnection;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -198,7 +198,7 @@ final class CommandOperationHelper {
 
     static <D, T> T executeCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
                                    final Decoder<D> decoder, final CommandReadTransformer<D, T> transformer, final boolean retryReads) {
-        return withConnectionSource(binding, new CallableWithSource<T>() {
+        return withReadConnectionSource(binding, new CallableWithSource<T>() {
             @Override
             public T call(final ConnectionSource source) {
                 return executeCommandWithConnection(binding, source, database, commandCreator, decoder,
@@ -404,7 +404,7 @@ final class CommandOperationHelper {
                                            final boolean retryReads,
                                            final SingleResultCallback<T> originalCallback) {
         final SingleResultCallback<T> errorHandlingCallback = errorHandlingCallback(originalCallback, LOGGER);
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
@@ -497,7 +497,7 @@ final class CommandOperationHelper {
             }
 
             private void retryableCommand(final Throwable originalError) {
-                withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+                withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                         if (t != null) {
@@ -837,7 +837,7 @@ final class CommandOperationHelper {
             private void retryableCommand(final Throwable originalError) {
                 final BsonDocument retryCommand = retryCommandModifier.apply(command);
                 logRetryExecute(retryCommand.getFirstKey(), originalError);
-                withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+                OperationHelper.withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                         if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -45,7 +45,8 @@ import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation to create a collection
@@ -390,7 +391,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
@@ -398,7 +399,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
                     errHandlingCallback.onResult(null, t);
                 } else {
                     final SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
-                    validateCollation(connection, collation, new OperationHelper.AsyncCallableWithConnection() {
+                    validateCollation(connection, collation, new AsyncCallableWithConnection() {
                         @Override
                         public void call(final AsyncConnection connection, final Throwable t) {
                             if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -45,6 +45,7 @@ import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation to create a collection
@@ -389,7 +390,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -59,6 +59,7 @@ import static com.mongodb.operation.OperationHelper.validateIndexRequestCollatio
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation that creates one or more indexes.
@@ -185,7 +186,7 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -59,7 +59,7 @@ import static com.mongodb.operation.OperationHelper.validateIndexRequestCollatio
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation that creates one or more indexes.
@@ -186,7 +186,7 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
@@ -42,6 +42,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation to create a user.
@@ -116,7 +117,7 @@ public class CreateUserOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation to create a user.
@@ -117,7 +117,7 @@ public class CreateUserOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -44,7 +44,7 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeast
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation to create a view.
@@ -161,7 +161,7 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -44,6 +44,7 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeast
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation to create a view.
@@ -160,7 +161,7 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * Operation to drop a Collection in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but
@@ -106,7 +106,7 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
@@ -42,6 +42,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * Operation to drop a Collection in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but
@@ -105,7 +106,7 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
@@ -36,7 +36,9 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
+import static com.mongodb.operation.OperationHelper.CallableWithConnection;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * Operation to drop a database in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but
@@ -86,7 +88,7 @@ public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOp
 
     @Override
     public Void execute(final WriteBinding binding) {
-        return withConnection(binding, new OperationHelper.CallableWithConnection<Void>() {
+        return withConnection(binding, new CallableWithConnection<Void>() {
             @Override
             public Void call(final Connection connection) {
                 executeCommand(binding, databaseName, getCommand(connection.getDescription()), connection, writeConcernErrorTransformer());
@@ -97,7 +99,7 @@ public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOp
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
@@ -36,6 +36,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * Operation to drop a database in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but
@@ -96,7 +97,7 @@ public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOp
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -46,7 +46,7 @@ import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation that drops an index.
@@ -171,7 +171,7 @@ public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOpera
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -46,6 +46,7 @@ import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation that drops an index.
@@ -170,7 +171,7 @@ public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOpera
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
@@ -41,7 +41,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation to remove a user.
@@ -98,7 +98,7 @@ public class DropUserOperation implements AsyncWriteOperation<Void>, WriteOperat
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
@@ -41,6 +41,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation to remove a user.
@@ -97,7 +98,7 @@ public class DropUserOperation implements AsyncWriteOperation<Void>, WriteOperat
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -76,7 +76,7 @@ import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 
@@ -761,7 +761,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
@@ -886,7 +886,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
         return new AsyncReadOperation<BsonDocument>() {
             @Override
             public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<BsonDocument> callback) {
-                withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+                withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource connectionSource, final AsyncConnection connection, final Throwable t) {
                         SingleResultCallback<BsonDocument> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -76,7 +76,8 @@ import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 
 /**
@@ -721,7 +722,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
+        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source) {
                 Connection connection = source.getConnection();
@@ -760,7 +761,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
@@ -885,7 +886,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
         return new AsyncReadOperation<BsonDocument>() {
             @Override
             public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<BsonDocument> callback) {
-                withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+                withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
                     @Override
                     public void call(final AsyncConnectionSource connectionSource, final AsyncConnection connection, final Throwable t) {
                         SingleResultCallback<BsonDocument> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -70,7 +70,7 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -256,7 +256,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -70,8 +70,8 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -228,7 +228,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
+        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source) {
                 Connection connection = source.getConnection();
@@ -256,7 +256,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -58,7 +58,7 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncReadConnection;
 import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 
@@ -191,7 +191,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 final SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -58,9 +58,9 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
+import static com.mongodb.operation.OperationHelper.withReadConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withReadConnectionSource;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
-import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionSource;
 
 /**
  * An operation that lists the indexes that have been created on a collection.  For flexibility, the type of each document returned is
@@ -163,7 +163,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
+        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source) {
                 Connection connection = source.getConnection();
@@ -191,7 +191,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withReadConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 final SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
@@ -52,6 +52,7 @@ import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 import static java.util.Arrays.asList;
@@ -519,7 +520,7 @@ MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistic
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<MapReduceStatistics> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<MapReduceStatistics> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
@@ -51,8 +51,9 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 import static java.util.Arrays.asList;
@@ -508,7 +509,7 @@ MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistic
      */
     @Override
     public MapReduceStatistics execute(final WriteBinding binding) {
-        return withConnection(binding, new OperationHelper.CallableWithConnection<MapReduceStatistics>() {
+        return withConnection(binding, new CallableWithConnection<MapReduceStatistics>() {
             @Override
             public MapReduceStatistics call(final Connection connection) {
                 validateCollation(connection, collation);
@@ -520,7 +521,7 @@ MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistic
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<MapReduceStatistics> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<MapReduceStatistics> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
@@ -59,7 +59,7 @@ import static com.mongodb.operation.OperationHelper.ConnectionReleasingWrappedCa
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.isRetryableWrite;
 import static com.mongodb.operation.OperationHelper.validateWriteRequests;
-import static com.mongodb.operation.OperationHelper.withConnection;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 import static com.mongodb.operation.OperationHelper.withReleasableConnection;
 
 /**
@@ -212,7 +212,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<BulkWriteResult> callback) {
         final SingleResultCallback<BulkWriteResult> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
@@ -353,7 +353,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     private void retryExecuteBatchesAsync(final AsyncWriteBinding binding, final BulkWriteBatch retryBatch,
                                           final Throwable originalError, final SingleResultCallback<BulkWriteResult> callback) {
         logRetryExecute(retryBatch.getPayload().getPayloadType().toString(), originalError);
-        withConnection(binding, new AsyncCallableWithConnectionAndSource() {
+        withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
@@ -59,7 +59,7 @@ import static com.mongodb.operation.OperationHelper.ConnectionReleasingWrappedCa
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.isRetryableWrite;
 import static com.mongodb.operation.OperationHelper.validateWriteRequests;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 import static com.mongodb.operation.OperationHelper.withReleasableConnection;
 
 /**
@@ -212,7 +212,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<BulkWriteResult> callback) {
         final SingleResultCallback<BulkWriteResult> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-        withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
@@ -353,7 +353,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     private void retryExecuteBatchesAsync(final AsyncWriteBinding binding, final BulkWriteBatch retryBatch,
                                           final Throwable originalError, final SingleResultCallback<BulkWriteResult> callback) {
         logRetryExecute(retryBatch.getPayload().getPayloadType().toString(), originalError);
-        withConnectionAsync(binding, new AsyncCallableWithConnectionAndSource() {
+        withAsyncConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
             public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -457,7 +457,7 @@ final class OperationHelper {
         }
     }
 
-    static <T> T withConnectionSource(final ReadBinding binding, final CallableWithSource<T> callable) {
+    static <T> T withReadConnectionSource(final ReadBinding binding, final CallableWithSource<T> callable) {
         ConnectionSource source = binding.getReadConnectionSource();
         try {
             return callable.call(source);
@@ -542,23 +542,19 @@ final class OperationHelper {
         }
     }
 
-    static void withConnection(final AsyncWriteBinding binding, final AsyncCallableWithConnection callable) {
+    static void withConnectionAsync(final AsyncWriteBinding binding, final AsyncCallableWithConnection callable) {
         binding.getWriteConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionCallback(callable), LOGGER));
     }
 
-    static void withConnection(final AsyncWriteBinding binding, final AsyncCallableWithConnectionAndSource callable) {
+    static void withConnectionAsync(final AsyncWriteBinding binding, final AsyncCallableWithConnectionAndSource callable) {
         binding.getWriteConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionAndSourceCallback(callable), LOGGER));
     }
 
-    static void withConnection(final AsyncReadBinding binding, final AsyncCallableWithConnection callable) {
-        binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionCallback(callable), LOGGER));
-    }
-
-    static void withConnection(final AsyncReadBinding binding, final AsyncCallableWithSource callable) {
+    static void withReadConnectionAsync(final AsyncReadBinding binding, final AsyncCallableWithSource callable) {
         binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithSourceCallback(callable), LOGGER));
     }
 
-    static void withConnection(final AsyncReadBinding binding, final AsyncCallableWithConnectionAndSource callable) {
+    static void withReadConnectionAsync(final AsyncReadBinding binding, final AsyncCallableWithConnectionAndSource callable) {
         binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionAndSourceCallback(callable), LOGGER));
     }
 
@@ -572,7 +568,7 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, t);
             } else {
-                withConnectionSource(source, callable);
+                withConnectionSourceAsyncCallableConnection(source, callable);
             }
         }
     }
@@ -587,12 +583,13 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, t);
             } else {
-                withConnectionSource(source, callable);
+                withConnectionSourceAsync(source, callable);
             }
         }
     }
 
-    private static void withConnectionSource(final AsyncConnectionSource source, final AsyncCallableWithConnection callable) {
+    private static void withConnectionSourceAsyncCallableConnection(final AsyncConnectionSource source,
+                                                                    final AsyncCallableWithConnection callable) {
         source.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
             public void onResult(final AsyncConnection connection, final Throwable t) {
@@ -606,11 +603,11 @@ final class OperationHelper {
         });
     }
 
-    private static void withConnectionSource(final AsyncConnectionSource source, final AsyncCallableWithSource callable) {
+    private static void withConnectionSourceAsync(final AsyncConnectionSource source, final AsyncCallableWithSource callable) {
         callable.call(source, null);
     }
 
-    private static void withConnectionSource(final AsyncConnectionSource source, final AsyncCallableWithConnectionAndSource callable) {
+    private static void withConnectionSourceAsync(final AsyncConnectionSource source, final AsyncCallableWithConnectionAndSource callable) {
         source.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
             public void onResult(final AsyncConnection result, final Throwable t) {
@@ -631,7 +628,7 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, null, t);
             } else {
-                withConnectionSource(source, callable);
+                withConnectionSourceAsync(source, callable);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -542,19 +542,19 @@ final class OperationHelper {
         }
     }
 
-    static void withConnectionAsync(final AsyncWriteBinding binding, final AsyncCallableWithConnection callable) {
+    static void withAsyncConnection(final AsyncWriteBinding binding, final AsyncCallableWithConnection callable) {
         binding.getWriteConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionCallback(callable), LOGGER));
     }
 
-    static void withConnectionAsync(final AsyncWriteBinding binding, final AsyncCallableWithConnectionAndSource callable) {
+    static void withAsyncConnection(final AsyncWriteBinding binding, final AsyncCallableWithConnectionAndSource callable) {
         binding.getWriteConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionAndSourceCallback(callable), LOGGER));
     }
 
-    static void withReadConnectionAsync(final AsyncReadBinding binding, final AsyncCallableWithSource callable) {
+    static void withAsyncReadConnection(final AsyncReadBinding binding, final AsyncCallableWithSource callable) {
         binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithSourceCallback(callable), LOGGER));
     }
 
-    static void withReadConnectionAsync(final AsyncReadBinding binding, final AsyncCallableWithConnectionAndSource callable) {
+    static void withAsyncReadConnection(final AsyncReadBinding binding, final AsyncCallableWithConnectionAndSource callable) {
         binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionAndSourceCallback(callable), LOGGER));
     }
 
@@ -568,7 +568,7 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, t);
             } else {
-                withConnectionSourceAsyncCallableConnection(source, callable);
+                withAsyncConnectionSourceCallableConnection(source, callable);
             }
         }
     }
@@ -583,12 +583,12 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, t);
             } else {
-                withConnectionSourceAsync(source, callable);
+                withAsyncConnectionSource(source, callable);
             }
         }
     }
 
-    private static void withConnectionSourceAsyncCallableConnection(final AsyncConnectionSource source,
+    private static void withAsyncConnectionSourceCallableConnection(final AsyncConnectionSource source,
                                                                     final AsyncCallableWithConnection callable) {
         source.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
@@ -603,11 +603,11 @@ final class OperationHelper {
         });
     }
 
-    private static void withConnectionSourceAsync(final AsyncConnectionSource source, final AsyncCallableWithSource callable) {
+    private static void withAsyncConnectionSource(final AsyncConnectionSource source, final AsyncCallableWithSource callable) {
         callable.call(source, null);
     }
 
-    private static void withConnectionSourceAsync(final AsyncConnectionSource source, final AsyncCallableWithConnectionAndSource callable) {
+    private static void withAsyncConnectionSource(final AsyncConnectionSource source, final AsyncCallableWithConnectionAndSource callable) {
         source.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
             public void onResult(final AsyncConnection result, final Throwable t) {
@@ -628,7 +628,7 @@ final class OperationHelper {
             if (t != null) {
                 callable.call(null, null, t);
             } else {
-                withConnectionSourceAsync(source, callable);
+                withAsyncConnectionSource(source, callable);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
@@ -38,6 +38,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation that renames the given collection to the new name.
@@ -131,7 +132,7 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
@@ -38,7 +38,9 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
+import static com.mongodb.operation.OperationHelper.CallableWithConnection;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation that renames the given collection to the new name.
@@ -121,7 +123,7 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
      */
     @Override
     public Void execute(final WriteBinding binding) {
-        return withConnection(binding, new OperationHelper.CallableWithConnection<Void>() {
+        return withConnection(binding, new CallableWithConnection<Void>() {
             @Override
             public Void call(final Connection connection) {
                 return executeCommand(binding, "admin", getCommand(connection.getDescription()), connection,
@@ -132,7 +134,7 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new OperationHelper.AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.operation.OperationHelper.withConnectionAsync;
+import static com.mongodb.operation.OperationHelper.withAsyncConnection;
 
 /**
  * An operation that updates a user.
@@ -117,7 +117,7 @@ public class UpdateUserOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnectionAsync(binding, new AsyncCallableWithConnection() {
+        withAsyncConnection(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);

--- a/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
@@ -42,6 +42,7 @@ import static com.mongodb.operation.UserOperationHelper.translateUserCommandExce
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.OperationHelper.withConnectionAsync;
 
 /**
  * An operation that updates a user.
@@ -116,7 +117,7 @@ public class UpdateUserOperation implements AsyncWriteOperation<Void>, WriteOper
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withConnection(binding, new AsyncCallableWithConnection() {
+        withConnectionAsync(binding, new AsyncCallableWithConnection() {
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d39ea62306615730a88eef3

Running the command `javac -Xlint OperationHelper.java` locally produced many warnings of the form:
```
OperationHelper.java:552: warning: [overloads] withConnection(AsyncReadBinding,AsyncCallableWithConnection) in OperationHelper is potentially ambiguous with withConnection(AsyncReadBinding,AsyncCallableWithSource) in OperationHelper
--
static void withConnection(final AsyncReadBinding binding, final AsyncCallableWithConnection callable) {
```
The interfaces `AsyncCallableWithSource` and `AsyncCallableWithConnection` contain methods with the same name and parameters that are of the same supertypes. Researching this revealed a straightforward method of resolving this warning - change the name of the `withConnection` methods. For the async methods, I use `withConnectionAsync`, and if there were still ambiguous warnings, I used a more descriptive name for the `withConnection` method.