### PR TITLE
JAVA-3279: Handle null results for reactive applications

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.async.client;
 
-import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
@@ -143,7 +142,7 @@ abstract class AbstractSubscription<TResult> implements Subscription {
     private void onNext(@Nullable final TResult next) {
         if (!isTerminated()) {
             if (next == null) {
-                onError(new MongoClientException("A null result for subscribing observers is no longer accepted"));
+                throw new NullPointerException();
             }
             try {
                 observer.onNext(next);

--- a/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 abstract class AbstractSubscription<TResult> implements Subscription {
     private static final Logger LOGGER = Loggers.getLogger("client");
+    private static final Object NULL_PLACEHOLDER = new Object();
     private final Observer<? super TResult> observer;
 
     /* protected by `this` */
@@ -37,7 +38,6 @@ abstract class AbstractSubscription<TResult> implements Subscription {
     private boolean isTerminated = false;
     /* protected by `this` */
 
-    private static final Object NULL_PLACEHOLDER = new Object();
     private final ConcurrentLinkedQueue<Object> resultsQueue = new ConcurrentLinkedQueue<Object>();
 
     AbstractSubscription(final Observer<? super TResult> observer) {

--- a/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.async.client
 
 import com.mongodb.Block
+import com.mongodb.MongoClientException
 import com.mongodb.MongoException
 import com.mongodb.async.SingleResultCallback
 import spock.lang.Specification
@@ -303,9 +304,9 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
         observer.requestMore(1)
 
         then:
-        notThrown(MongoException)
         observer.assertTerminalEvent()
         observer.assertErrored()
+        observer.getOnErrorEvents().first() instanceof MongoClientException
     }
 
     def 'should throw the exception if calling onComplete raises one'() {

--- a/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
@@ -17,7 +17,6 @@
 package com.mongodb.async.client
 
 import com.mongodb.Block
-import com.mongodb.MongoClientException
 import com.mongodb.MongoException
 import com.mongodb.async.SingleResultCallback
 import spock.lang.Specification
@@ -306,7 +305,7 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
         then:
         observer.assertTerminalEvent()
         observer.assertErrored()
-        observer.getOnErrorEvents().first() instanceof MongoClientException
+        observer.getOnErrorEvents().first() instanceof NullPointerException
     }
 
     def 'should throw the exception if calling onComplete raises one'() {

--- a/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
@@ -257,7 +257,7 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
         observe(new Block<SingleResultCallback<Void>>(){
             @Override
             void apply(final SingleResultCallback<Void> callback) {
-                callback.onResult(null, null)
+                callback.onResult(1, null)
             }
         }).subscribe(observer)
 
@@ -266,7 +266,7 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
 
         then:
         observer.assertNoErrors()
-        observer.assertReceivedOnNext([])
+        observer.assertReceivedOnNext([1])
         observer.assertTerminalEvent()
     }
 
@@ -277,6 +277,25 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
             @Override
             void apply(final SingleResultCallback<Integer> callback) {
                 throw new MongoException('failed')
+            }
+        }).subscribe(observer)
+
+        when:
+        observer.requestMore(1)
+
+        then:
+        notThrown(MongoException)
+        observer.assertTerminalEvent()
+        observer.assertErrored()
+    }
+
+    def 'should call onError on a null result'() {
+        given:
+        def observer = new TestObserver()
+        observe(new Block<SingleResultCallback<Void>>() {
+            @Override
+            void apply(final SingleResultCallback<Void> callback) {
+                callback.onResult(null, null);
             }
         }).subscribe(observer)
 


### PR DESCRIPTION
Throw an `UnsupportedOperationException` in `onNext` if the result is null.