### PR TITLE
JAVA-3320: Allow duplicate annotations in classes for use in POJO codec

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/PropertyMetadata.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyMetadata.java
@@ -61,6 +61,9 @@ final class PropertyMetadata<T> {
 
     public PropertyMetadata<T> addReadAnnotation(final Annotation annotation) {
         if (readAnnotations.containsKey(annotation.annotationType())) {
+            if (annotation.equals(readAnnotations.get(annotation.annotationType()))) {
+                return this;
+            }
             throw new CodecConfigurationException(format("Read annotation %s for '%s' already exists in %s", annotation.annotationType(),
                     name, declaringClassName));
         }
@@ -74,6 +77,9 @@ final class PropertyMetadata<T> {
 
     public PropertyMetadata<T> addWriteAnnotation(final Annotation annotation) {
         if (writeAnnotations.containsKey(annotation.annotationType())) {
+            if (annotation.equals(writeAnnotations.get(annotation.annotationType()))) {
+                return this;
+            }
             throw new CodecConfigurationException(format("Write annotation %s for '%s' already exists in %s", annotation.annotationType(),
                     name, declaringClassName));
         }

--- a/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
@@ -23,6 +23,7 @@ import org.bson.codecs.pojo.entities.conventions.AnnotationCollision;
 import org.bson.codecs.pojo.entities.conventions.AnnotationDefaultsModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationNameCollision;
 import org.bson.codecs.pojo.entities.conventions.AnnotationWithObjectIdModel;
+import org.bson.codecs.pojo.entities.conventions.AnnotationWriteCollision;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMethodReturnTypeModel;
@@ -141,6 +142,11 @@ public final class ConventionsTest {
     @Test(expected = CodecConfigurationException.class)
     public void testAnnotationCollision() {
         ClassModel.builder(AnnotationCollision.class).conventions(DEFAULT_CONVENTIONS).build();
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testAnnotationWriteCollision() {
+        ClassModel.builder(AnnotationWriteCollision.class).conventions(DEFAULT_CONVENTIONS).build();
     }
 
     @Test(expected = CodecConfigurationException.class)

--- a/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
@@ -19,6 +19,7 @@ package org.bson.codecs.pojo;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationBsonPropertyIdModel;
+import org.bson.codecs.pojo.entities.conventions.AnnotationCollision;
 import org.bson.codecs.pojo.entities.conventions.AnnotationDefaultsModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationNameCollision;
 import org.bson.codecs.pojo.entities.conventions.AnnotationWithObjectIdModel;
@@ -135,6 +136,11 @@ public final class ConventionsTest {
         assertEquals("stringField", idPropertyModel.getName());
         assertEquals("_id", idPropertyModel.getWriteName());
         assertNull(idPropertyModel.useDiscriminator());
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testAnnotationCollision() {
+        ClassModel.builder(AnnotationCollision.class).conventions(DEFAULT_CONVENTIONS).build();
     }
 
     @Test(expected = CodecConfigurationException.class)

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -81,6 +81,7 @@ import org.bson.codecs.pojo.entities.conventions.CreatorInSuperClassModelImpl;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsMethodModel;
+import org.bson.codecs.pojo.entities.DuplicateAnnotationAllowedModel;
 import org.bson.codecs.pojo.entities.conventions.InterfaceModel;
 import org.bson.codecs.pojo.entities.conventions.InterfaceModelImplA;
 import org.bson.codecs.pojo.entities.conventions.InterfaceModelImplB;
@@ -420,6 +421,11 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 "{'_id': {'$oid': '123412341234123412341234'}, 'level': 'top',"
                         + "'left': {'level': 'left-1', 'left': {'level': 'left-2'}},"
                         + "'right': {'level': 'right-1'}}"));
+
+        data.add(new TestData("DuplicateAnnotationAllowedModel",
+                new DuplicateAnnotationAllowedModel("abc"),
+                getPojoCodecProviderBuilder(DuplicateAnnotationAllowedModel.class).conventions(Conventions.DEFAULT_CONVENTIONS),
+                "{'_id': 'abc'}"));
 
         return data;
     }

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/DuplicateAnnotationAllowedModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/DuplicateAnnotationAllowedModel.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import javax.annotation.Nullable;
+
+public class DuplicateAnnotationAllowedModel {
+
+    @Nullable
+    private String id;
+
+    public DuplicateAnnotationAllowedModel() {
+    }
+
+    public DuplicateAnnotationAllowedModel(final String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getId() {
+        return id;
+    }
+
+    public void setId(@Nullable final String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DuplicateAnnotationAllowedModel that = (DuplicateAnnotationAllowedModel) o;
+
+        return (id != null ? id.equals(that.id) : that.id == null);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/DuplicateAnnotationAllowedModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/DuplicateAnnotationAllowedModel.java
@@ -16,12 +16,21 @@
 
 package org.bson.codecs.pojo.entities;
 
+import org.bson.codecs.pojo.annotations.BsonIgnore;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
 import javax.annotation.Nullable;
 
 public class DuplicateAnnotationAllowedModel {
 
     @Nullable
     private String id;
+
+    @BsonIgnore
+    private String ignoredString;
+
+    @BsonProperty("property")
+    private String propertyString;
 
     public DuplicateAnnotationAllowedModel() {
     }
@@ -37,6 +46,26 @@ public class DuplicateAnnotationAllowedModel {
 
     public void setId(@Nullable final String id) {
         this.id = id;
+    }
+
+    @BsonIgnore
+    public String getIgnoredString() {
+        return ignoredString;
+    }
+
+    @BsonIgnore
+    public void setIgnoredString(final String ignoredString) {
+        this.ignoredString = ignoredString;
+    }
+
+    @BsonProperty("property")
+    public String getPropertyString() {
+        return propertyString;
+    }
+
+    @BsonProperty("property")
+    public void setPropertyString(final String propertyString) {
+        this.propertyString = propertyString;
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/AnnotationCollision.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/AnnotationCollision.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public final class AnnotationCollision {
+
+    public String id;
+
+    @BsonProperty("color")
+    private String color;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    @BsonProperty("theme")
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(final String color) {
+        this.color = color;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/AnnotationWriteCollision.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/AnnotationWriteCollision.java
@@ -18,12 +18,13 @@ package org.bson.codecs.pojo.entities.conventions;
 
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
-public final class AnnotationCollision {
+public final class AnnotationWriteCollision {
 
     public String id;
 
     @BsonProperty("color")
     private String color;
+
 
     public String getId() {
         return id;
@@ -33,11 +34,11 @@ public final class AnnotationCollision {
         this.id = id;
     }
 
-    @BsonProperty("theme")
     public String getColor() {
         return color;
     }
 
+    @BsonProperty("theme")
     public void setColor(final String color) {
         this.color = color;
     }


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d4353ec1e2d1745098aa64d

Allow the same annotation for a property only if it equals the existing annotation.