### PR TITLE
JAVA-3364: Make ClassModel immutable

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ClassModel.java
+++ b/bson/src/main/org/bson/codecs/pojo/ClassModel.java
@@ -16,8 +16,7 @@
 
 package org.bson.codecs.pojo;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -46,13 +45,13 @@ public final class ClassModel<T> {
         this.name = clazz.getSimpleName();
         this.type = clazz;
         this.hasTypeParameters = clazz.getTypeParameters().length > 0;
-        this.propertyNameToTypeParameterMap = new HashMap<String, TypeParameterMap>(propertyNameToTypeParameterMap);
+        this.propertyNameToTypeParameterMap = Collections.unmodifiableMap(propertyNameToTypeParameterMap);
         this.instanceCreatorFactory = instanceCreatorFactory;
         this.discriminatorEnabled = discriminatorEnabled;
         this.discriminatorKey = discriminatorKey;
         this.discriminator = discriminator;
         this.idPropertyModelHolder = idPropertyModelHolder;
-        this.propertyModels = new ArrayList<PropertyModel<?>>(propertyModels);
+        this.propertyModels = Collections.unmodifiableList(propertyModels);
     }
 
     /**
@@ -133,7 +132,7 @@ public final class ClassModel<T> {
      * @return the list of properties
      */
     public List<PropertyModel<?>> getPropertyModels() {
-        return new ArrayList<PropertyModel<?>>(propertyModels);
+        return propertyModels;
     }
 
     /**
@@ -213,7 +212,7 @@ public final class ClassModel<T> {
         result = 31 * result + (discriminatorEnabled ? 1 : 0);
         result = 31 * result + (getDiscriminatorKey() != null ? getDiscriminatorKey().hashCode() : 0);
         result = 31 * result + (getDiscriminator() != null ? getDiscriminator().hashCode() : 0);
-        result = 31 * result + getIdPropertyModelHolder().hashCode();
+        result = 31 * result + (getIdPropertyModelHolder() != null ? getIdPropertyModelHolder().hashCode() : 0);
         result = 31 * result + getPropertyModels().hashCode();
         result = 31 * result + getPropertyNameToTypeParameterMap().hashCode();
         return result;
@@ -224,7 +223,7 @@ public final class ClassModel<T> {
     }
 
     Map<String, TypeParameterMap> getPropertyNameToTypeParameterMap() {
-        return new HashMap<String, TypeParameterMap>(propertyNameToTypeParameterMap);
+        return propertyNameToTypeParameterMap;
     }
 
 }

--- a/bson/src/main/org/bson/codecs/pojo/ClassModel.java
+++ b/bson/src/main/org/bson/codecs/pojo/ClassModel.java
@@ -16,6 +16,8 @@
 
 package org.bson.codecs.pojo;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,13 +46,13 @@ public final class ClassModel<T> {
         this.name = clazz.getSimpleName();
         this.type = clazz;
         this.hasTypeParameters = clazz.getTypeParameters().length > 0;
-        this.propertyNameToTypeParameterMap = propertyNameToTypeParameterMap;
+        this.propertyNameToTypeParameterMap = new HashMap<String, TypeParameterMap>(propertyNameToTypeParameterMap);
         this.instanceCreatorFactory = instanceCreatorFactory;
         this.discriminatorEnabled = discriminatorEnabled;
         this.discriminatorKey = discriminatorKey;
         this.discriminator = discriminator;
         this.idPropertyModelHolder = idPropertyModelHolder;
-        this.propertyModels = propertyModels;
+        this.propertyModels = new ArrayList<PropertyModel<?>>(propertyModels);
     }
 
     /**
@@ -131,7 +133,7 @@ public final class ClassModel<T> {
      * @return the list of properties
      */
     public List<PropertyModel<?>> getPropertyModels() {
-        return propertyModels;
+        return new ArrayList<PropertyModel<?>>(propertyModels);
     }
 
     /**
@@ -211,7 +213,7 @@ public final class ClassModel<T> {
         result = 31 * result + (discriminatorEnabled ? 1 : 0);
         result = 31 * result + (getDiscriminatorKey() != null ? getDiscriminatorKey().hashCode() : 0);
         result = 31 * result + (getDiscriminator() != null ? getDiscriminator().hashCode() : 0);
-        result = 31 * result + (getIdPropertyModelHolder() != null ? getIdPropertyModelHolder().hashCode() : 0);
+        result = 31 * result + getIdPropertyModelHolder().hashCode();
         result = 31 * result + getPropertyModels().hashCode();
         result = 31 * result + getPropertyNameToTypeParameterMap().hashCode();
         return result;
@@ -222,7 +224,7 @@ public final class ClassModel<T> {
     }
 
     Map<String, TypeParameterMap> getPropertyNameToTypeParameterMap() {
-        return propertyNameToTypeParameterMap;
+        return new HashMap<String, TypeParameterMap>(propertyNameToTypeParameterMap);
     }
 
 }


### PR DESCRIPTION
Use defensive copies to make `ClassModel` immutable. This will prevent any changes to the hash code of any `ClassModel` objects and avoid the race condition in `PojoCodecImpl#specializedPojoCodec` between the `containsKey` and `get` call.