### PR TITLE
JAVA-3434: Fix Javadoc warning about fetching Java 11 Javadoc

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -7,9 +7,9 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #            Main Program                  #
 ############################################
 
-echo "Compiling java driver with jdk9"
+echo "Compiling java driver with jdk11"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 ./gradlew -version
 ./gradlew -PxmlReports.enabled=true --info -x test clean check jar testClasses docs

--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -20,8 +20,8 @@ export ORG_GRADLE_PROJECT_signing_keyId=${SIGNING_KEY_ID}
 export ORG_GRADLE_PROJECT_signing_password=${SIGNING_PASSWORD}
 export ORG_GRADLE_PROJECT_signing_secretKeyRingFile=${PROJECT_DIRECTORY}/secring.gpg
 
-echo "Publishing snapshot with jdk9"
-export JAVA_HOME="/opt/java/jdk9"
+echo "Publishing snapshot with jdk11"
+export JAVA_HOME="/opt/java/jdk11"
 
 ./gradlew -version
 ./gradlew publishSnapshots

--- a/.evergreen/run-connectivity-tests.sh
+++ b/.evergreen/run-connectivity-tests.sh
@@ -18,7 +18,7 @@ JDK=${JDK:-jdk}
 echo "Running connectivity tests with ${JDK}"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 ./gradlew -version
 

--- a/.evergreen/run-embedded-tests.sh
+++ b/.evergreen/run-embedded-tests.sh
@@ -14,7 +14,7 @@ JDK=${JDK:-jdk}
 ############################################
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 export EMBEDDED_PATH="${PROJECT_DIRECTORY}/tmp/mongo-embedded-java"
 mkdir -p ${EMBEDDED_PATH}

--- a/.evergreen/run-gssapi-auth-test.sh
+++ b/.evergreen/run-gssapi-auth-test.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Supported/used environment variables:
 #       MONGODB_URI             Set the URI, including username/password to use to connect to the server via PLAIN authentication mechanism
 #       JDK                     Set the version of java to be used.  Java versions can be set from the java toolchain /opt/java
-#                               "jdk5", "jdk6", "jdk7", "jdk8", "jdk9"
+#                               "jdk5", "jdk6", "jdk7", "jdk8", "jdk9", "jdk11"
 #       KDC                     The KDC
 #       REALM                   The realm
 #       KEYTAB_BASE64           The BASE64-encoded keytab
@@ -31,10 +31,10 @@ com.sun.security.jgss.krb5.initiate {
 };
 EOF
 
-echo "Compiling java driver with jdk9"
+echo "Compiling java driver with jdk11"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-mmapv1-storage-test.sh
+++ b/.evergreen/run-mmapv1-storage-test.sh
@@ -15,10 +15,10 @@ JDK=${JDK:-jdk}
 
 echo "Running MMAPv1 Storage Test"
 
-echo "Compiling java driver with jdk9"
+echo "Compiling java driver with jdk11"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -11,7 +11,7 @@ tar xf parallel.tgz
 tar xf single_and_multi_document.tgz
 cd ..
 
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 export TEST_PATH="${PROJECT_DIRECTORY}/driver-performance-test-data/"
 export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"

--- a/.evergreen/run-plain-auth-test.sh
+++ b/.evergreen/run-plain-auth-test.sh
@@ -17,7 +17,7 @@ JDK=${JDK:-jdk}
 echo "Running PLAIN authentication tests"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-socket-tests.sh
+++ b/.evergreen/run-socket-tests.sh
@@ -10,7 +10,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #                               Supported values: "server", "replica_set", "sharded_cluster"
 #       COMPRESSOR              Set to enable compression. Values are "snappy" and "zlib" (default is no compression)
 #       JDK                     Set the version of java to be used.  Java versions can be set from the java toolchain /opt/java
-#                               "jdk5", "jdk6", "jdk7", "jdk8", "jdk9"
+#                               "jdk5", "jdk6", "jdk7", "jdk8", "jdk9", "jdk11"
 
 AUTH=${AUTH:-noauth}
 MONGODB_URI=${MONGODB_URI:-}
@@ -48,7 +48,7 @@ fi
 echo "Running $AUTH tests over for $TOPOLOGY and connecting to $MONGODB_URI"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -32,7 +32,7 @@ else
 fi
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk9"
+export JAVA_HOME="/opt/java/jdk11"
 
 
 ############################################


### PR DESCRIPTION
Updated the shell scripts to use the latest version of Java. This resolves the Javadoc warnings.