### PR TITLE
JAVARS-216: AbstractSubscription#onError must call the onError method of the observer

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
@@ -124,7 +124,11 @@ abstract class AbstractSubscription<TResult> implements Subscription {
 
     void onError(final Throwable t) {
         if (terminalAction()) {
-            postTerminate();
+            try {
+                postTerminate();
+            } catch (Throwable throwable) {
+                // fall through
+            }
             try {
                 observer.onError(t);
             } catch (Throwable t1) {

--- a/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/AbstractSubscription.java
@@ -124,11 +124,7 @@ abstract class AbstractSubscription<TResult> implements Subscription {
 
     void onError(final Throwable t) {
         if (terminalAction()) {
-            try {
-                postTerminate();
-            } catch (Throwable throwable) {
-                // fall through
-            }
+            postTerminate();
             try {
                 observer.onError(t);
             } catch (Throwable t1) {

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterableSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterableSubscription.java
@@ -65,8 +65,12 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
 
     @Override
     void postTerminate() {
-        if (batchCursor != null) {
-            batchCursor.close();
+        try {
+            if (batchCursor != null) {
+                batchCursor.close();
+            }
+        } catch (Exception e) {
+            // do nothing
         }
     }
 


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5da5d85fd1fe077394102bf6
Failed tests on Evergreen are due to the failing test `ProjectionFunctionalSpecification#metaTextScore`.