### PR TITLE
JAVA-3487: Properly close session bindings in change streams

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
@@ -119,6 +119,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
 
         SessionBindingConnectionSource(final ConnectionSource wrapped) {
             this.wrapped = wrapped;
+            ClientSessionBinding.this.retain();
         }
 
         @Override
@@ -140,6 +141,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
         @SuppressWarnings("checkstyle:methodlength")
         public ConnectionSource retain() {
             wrapped = wrapped.retain();
+            ClientSessionBinding.this.retain();
             return this;
         }
 
@@ -151,7 +153,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
         @Override
         public void release() {
             wrapped.release();
-            closeSessionIfCountIsZero();
+            ClientSessionBinding.this.release();
         }
     }
 


### PR DESCRIPTION
After extensive debugging of the test provided by the reporter, I found that `SessionBindingConnectionSource` was prematurely closing the `ClientSessionBinding`, causing the exception seen by the reporter. Calling the `release` and `retain` methods from the parent class resolves this issue.

Evergreen patch: https://evergreen.mongodb.com/version/5dbb19d60305b92082c6f0ee