### PR TITLE
Prevent batch cursor from closing prematurely in reactive streams.

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoIterableSubscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterableSubscription.java
@@ -70,10 +70,10 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
             if (batchCursor != null) {
                 boolean closeCursor = false;
                 synchronized (this) {
-                    if (!isReading) {
-                        closeCursor = true;
-                    } else {
+                    if (isReading) {
                         terminateWhenRead = true;
+                    } else {
+                        closeCursor = true;
                     }
                 }
                 if (closeCursor) {


### PR DESCRIPTION
JAVA-3487

If a read is in progress when calling `postTerminate`, set a variable to postpone closing the batch cursor until the read is completed.
Evergreen patch: https://evergreen.mongodb.com/version/5dc301c22fbabe244c31c161

I have created the ticket https://jira.mongodb.org/browse/JAVARS-219 to add a version of the reporter's test to the reactive streams repo. Testing for this fix was done in the `4.x` branch where there was access to the reactive streams classes.