### PR TITLE
JAVA-3508: ConnectionSource does not retain a reference to its parent binding

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/ClientSessionBinding.java
+++ b/driver-async/src/main/com/mongodb/async/client/ClientSessionBinding.java
@@ -156,6 +156,7 @@ class ClientSessionBinding implements AsyncReadWriteBinding {
 
         SessionBindingAsyncConnectionSource(final AsyncConnectionSource wrapped) {
             this.wrapped = wrapped;
+            ClientSessionBinding.this.retain();
         }
 
         @Override
@@ -176,6 +177,7 @@ class ClientSessionBinding implements AsyncReadWriteBinding {
         @Override
         public AsyncConnectionSource retain() {
             wrapped = wrapped.retain();
+            ClientSessionBinding.this.retain();
             return this;
         }
 
@@ -187,7 +189,7 @@ class ClientSessionBinding implements AsyncReadWriteBinding {
         @Override
         public void release() {
             wrapped.release();
-            closeSessionIfCountIsZero();
+            ClientSessionBinding.this.release();
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBinding.java
@@ -208,16 +208,13 @@ public class AsyncSingleConnectionBinding extends AbstractReferenceCounted imple
         }
 
         public AsyncConnectionSource retain() {
-            super.retain();
+            AsyncSingleConnectionBinding.this.retain();
             return this;
         }
 
         @Override
         public void release() {
-            super.release();
-            if (super.getCount() == 0) {
-                AsyncSingleConnectionBinding.this.release();
-            }
+            AsyncSingleConnectionBinding.this.release();
         }
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
@@ -119,6 +119,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
 
         SessionBindingConnectionSource(final ConnectionSource wrapped) {
             this.wrapped = wrapped;
+            ClientSessionBinding.this.retain();
         }
 
         @Override
@@ -140,6 +141,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
         @SuppressWarnings("checkstyle:methodlength")
         public ConnectionSource retain() {
             wrapped = wrapped.retain();
+            ClientSessionBinding.this.retain();
             return this;
         }
 
@@ -151,7 +153,7 @@ public class ClientSessionBinding implements ReadWriteBinding {
         @Override
         public void release() {
             wrapped.release();
-            closeSessionIfCountIsZero();
+            ClientSessionBinding.this.release();
         }
     }
 


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5dd4ba2a2fbabe2bce5e24ae