### PR TITLE
JAVA-3487: Extend AsyncChangeStreamBatchCursor to be reference counted

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -91,18 +91,18 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
 
     @Override
     public void close() {
-        boolean closed;
-        boolean opInProgress;
+        boolean closeCursor = false;
+
         synchronized (this) {
-            closed = !isClosePending && isClosed;
-            opInProgress = isOperationInProgress;
-            if (!closed && opInProgress) {
+            if (isOperationInProgress) {
                 isClosePending = true;
+            } else {
+                closeCursor = !isClosed;
+                isClosed = true;
             }
-            isClosed = true;
         }
 
-        if (!closed && !opInProgress) {
+        if (closeCursor) {
             wrapped.close();
             binding.release();
         }
@@ -120,11 +120,9 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
 
     @Override
     public boolean isClosed() {
-        boolean closed = false;
         synchronized (this) {
-            closed = isClosed;
+            return isClosed;
         }
-        return closed;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -99,6 +99,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
             } else {
                 closeCursor = !isClosed;
                 isClosed = true;
+                isClosePending = false;
             }
         }
 
@@ -190,7 +191,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
     private void resumeableOperation(final AsyncBlock asyncBlock, final SingleResultCallback<List<RawBsonDocument>> callback,
                                      final boolean tryNext) {
         synchronized (this) {
-            if (isClosed && !isClosePending) {
+            if (isClosed) {
                 callback.onResult(null, new MongoException(format("%s called after the cursor was closed.",
                         tryNext ? "tryNext()" : "next()")));
                 return;

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -120,6 +120,7 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
             } else {
                 killCursor = !isClosed;
                 isClosed = true;
+                isClosePending = false;
             }
         }
 
@@ -197,7 +198,7 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
                 callback.onResult(null, null);
             } else {
                 synchronized (this) {
-                    if (isClosed && !isClosePending) {
+                    if (isClosed) {
                         callback.onResult(null, new MongoException(format("%s called after the cursor was closed.",
                                 tryNext ? "tryNext()" : "next()")));
                         return;

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncChangeStreamBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncChangeStreamBatchCursorSpecification.groovy
@@ -16,9 +16,14 @@
 
 package com.mongodb.operation
 
+import com.mongodb.MongoException
+import com.mongodb.async.FutureResultCallback
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.binding.AsyncReadBinding
+import org.bson.Document
 import spock.lang.Specification
+
+import static java.util.concurrent.TimeUnit.SECONDS
 
 class AsyncChangeStreamBatchCursorSpecification extends Specification {
 
@@ -85,5 +90,65 @@ class AsyncChangeStreamBatchCursorSpecification extends Specification {
 
         then:
         cursor.isClosed()
+    }
+
+    def 'should not close the cursor in tryNext if the cursor was closed before tryNext completed'() {
+        def changeStreamOpertation = Stub(ChangeStreamOperation)
+        def binding = Mock(AsyncReadBinding)
+        def wrapped = Mock(AsyncQueryBatchCursor)
+        def callback = Stub(SingleResultCallback)
+        def cursor = new AsyncChangeStreamBatchCursor(changeStreamOpertation, wrapped, binding, null)
+
+        when:
+        cursor.tryNext(callback)
+
+        then:
+        1 * wrapped.tryNext(_) >> {
+            // Simulate the user calling close while wrapped.next() is in flight
+            cursor.close()
+            it[0].onResult(null, null)
+        }
+
+        then:
+        noExceptionThrown()
+
+        then:
+        cursor.isClosed()
+    }
+
+    def 'should throw a MongoException when next/tryNext is called after the cursor is closed'() {
+        def changeStreamOpertation = Stub(ChangeStreamOperation)
+        def binding = Mock(AsyncReadBinding)
+        def wrapped = Mock(AsyncQueryBatchCursor)
+        def cursor = new AsyncChangeStreamBatchCursor(changeStreamOpertation, wrapped, binding, null)
+
+        given:
+        cursor.close()
+
+        when:
+        nextBatch(cursor)
+
+        then:
+        def exception = thrown(MongoException)
+        exception.getMessage() == 'next() called after the cursor was closed.'
+
+        when:
+        tryNextBatch(cursor)
+
+        then:
+        exception = thrown(MongoException)
+        exception.getMessage() == 'tryNext() called after the cursor was closed.'
+    }
+
+    List<Document> nextBatch(AsyncChangeStreamBatchCursor cursor) {
+        def futureResultCallback = new FutureResultCallback()
+        cursor.next(futureResultCallback)
+        futureResultCallback.get(1, SECONDS)
+    }
+
+    List<Document> tryNextBatch(AsyncChangeStreamBatchCursor cursor) {
+        def futureResultCallback = new FutureResultCallback()
+        cursor.tryNext(futureResultCallback)
+        futureResultCallback.get(1, SECONDS)
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncChangeStreamBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncChangeStreamBatchCursorSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.operation
 
-import com.mongodb.MongoException
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.binding.AsyncReadBinding
 import spock.lang.Specification
@@ -25,13 +24,11 @@ class AsyncChangeStreamBatchCursorSpecification extends Specification {
 
     def 'should call the underlying AsyncQueryBatchCursor'() {
         given:
-        def changeStreamOperation = Stub(ChangeStreamOperation)
-        def binding = Mock(AsyncReadBinding) {
-            getCount() >>> [2, 1, 0]
-        }
+        def changeStreamOpertation = Stub(ChangeStreamOperation)
+        def binding = Mock(AsyncReadBinding)
         def wrapped = Mock(AsyncQueryBatchCursor)
         def callback = Stub(SingleResultCallback)
-        def cursor = new AsyncChangeStreamBatchCursor(changeStreamOperation, wrapped, binding, null)
+        def cursor = new AsyncChangeStreamBatchCursor(changeStreamOpertation, wrapped, binding, null)
 
         when:
         cursor.setBatchSize(10)
@@ -44,54 +41,24 @@ class AsyncChangeStreamBatchCursorSpecification extends Specification {
 
         then:
         1 * wrapped.tryNext(_) >> { it[0].onResult(null, null) }
-        1 * binding.retain()
-        1 * binding.release()
 
         when:
         cursor.next(callback)
 
         then:
         1 * wrapped.next(_) >> { it[0].onResult(null, null) }
-        1 * binding.retain()
-        1 * binding.release()
 
         when:
-        cursor.next(callback)
-
-        then:
-        1 * wrapped.next(_) >> { it[0].onResult(null, new MongoException(11601, 'Failure')) }
-        1 * binding.retain()
-        1 * binding.release()
-
-        when:
-        cursor.retain()
         cursor.close()
 
         then:
-        1 * wrapped.isClosed() >> {
-            false
-        }
-        0 * wrapped.close()
-        0 * binding.release()
-
-        when:
-        cursor.release()
-        cursor.close()
-
-        then:
-        1 * wrapped.isClosed() >> {
-            false
-        }
         1 * wrapped.close()
-        2 * binding.release()
+        1 * binding.release()
 
         when:
         cursor.close()
 
         then:
-        1 * wrapped.isClosed() >> {
-            true
-        }
         0 * wrapped.close()
         0 * binding.release()
     }

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -115,7 +115,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         connection.getCount() == 0
         connectionSource.getCount() == 0
-        cursor.getCount() == 0
 
         where:
         serverVersion                | firstBatch
@@ -133,19 +132,16 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         def cursor = new AsyncQueryBatchCursor<Document>(queryResult(FIRST_BATCH, 0), 0, 0, 0, CODEC, connectionSource, null)
 
         then:
-        cursor.getCount() == 1
         nextBatch(cursor) == FIRST_BATCH
 
         then:
         connectionSource.getCount() == 0
-        cursor.getCount() == 1
 
         then:
         nextBatch(cursor) == null
 
         then:
         connectionSource.getCount() == 0
-        cursor.getCount() == 1
 
         when:
         nextBatch(cursor)
@@ -166,16 +162,10 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         when:
         def cursor = new AsyncQueryBatchCursor<Document>(queryResult(firstBatch), 6, 2, 0, CODEC, connectionSource, null)
-
-        then:
-        cursor.getCount() == 1
-
-        when:
         def batch = nextBatch(cursor)
 
         then:
         batch == firstBatch
-        cursor.getCount() == 1
 
         when:
         batch = tryNextBatch(cursor)
@@ -191,7 +181,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         batch == null
         connectionA.getCount() == 0
         connectionSource.getCount() == 1
-        cursor.getCount() == 1
 
         when:
         batch = tryNextBatch(cursor)
@@ -216,7 +205,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         batch == thirdBatch
         connectionB.getCount() == 0
         connectionSource.getCount() == 0
-        cursor.getCount() == 1
 
         when:
         batch = tryNextBatch(cursor)
@@ -224,7 +212,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         batch == null
         connectionSource.getCount() == 0
-        cursor.getCount() == 1
 
         where:
         serverVersion                | commandAsync
@@ -321,7 +308,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
                 it[2].onResult(null, null)
             }
         }
-        cursor.getCount() == 1
 
         when:
         cursor.close()
@@ -332,7 +318,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         connection.getCount() == 0
         connectionSource.getCount() == 0
-        cursor.getCount() == 0
 
         where:
         serverVersion << [new ServerVersion([3, 2, 0]), new ServerVersion([3, 0, 0])]
@@ -482,7 +467,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         connectionA.getCount() == 0
         connectionSource.getCount() == 0
-        cursor.getCount() == 1
 
         where:
         serverVersion                | commandAsync         | response
@@ -517,7 +501,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         nextBatch(cursor)
-        cursor.getCount() == 1
 
         when:
         nextBatch(cursor)
@@ -527,14 +510,12 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         connectionSource.getCount() == 1
-        cursor.getCount() == 1
 
         when:
         cursor.close()
 
         then:
         connectionSource.getCount() == 0
-        cursor.getCount() == 0
     }
 
     def 'should handle errors when calling getMore'() {


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5dd70aa9850e614498f53cb4

Adding reference counting to AsyncChangeStreamBatchCursor to protect the underlying session from closing prematurely. The test case submitted by the reporter no longer throws the exception shown in the ticket.