### PR TITLE
JAVA-3513: mongos pinning test expects no unpinning on MaxTimeoutMSExpired

### DIFF
--- a/driver-core/src/test/resources/transactions/pin-mongos.json
+++ b/driver-core/src/test/resources/transactions/pin-mongos.json
@@ -827,7 +827,6 @@
     },
     {
       "description": "remain pinned after non-transient error on commit",
-      "skipReason": "SPEC-1320",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -876,7 +875,7 @@
                 "failCommands": [
                   "commitTransaction"
                 ],
-                "errorCode": 50
+                "errorCode": 51
               }
             }
           }
@@ -888,7 +887,7 @@
             "errorLabelsOmit": [
               "TransientTransactionError"
             ],
-            "errorCode": 50
+            "errorCode": 51
           }
         },
         {


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5ddc651d32f417340d6da348