### PR TITLE
JAVA-3298: Specify behavior where connection string contains auth DB but no credentials

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -693,9 +693,6 @@ public class ConnectionString {
                     mechanism = AuthenticationMechanism.fromMechanismName(value);
                 }
             } else if (key.equals("authsource")) {
-                if (userName == null && !isSrvProtocol) {
-                    throw new IllegalArgumentException("A username is required when an authentication source is specified");
-                }
                 authSource = value;
             } else if (key.equals("gssapiservicename")) {
                 gssapiServiceName = value;

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -324,9 +324,14 @@ public class ConnectionString {
                 userName = urldecode(userInfo);
             } else {
                 idx = userInfo.indexOf(":");
+                if (idx == 0) {
+                    throw new IllegalArgumentException("No username is provided in the connection string");
+                }
                 userName = urldecode(userInfo.substring(0, idx));
                 password = urldecode(userInfo.substring(idx + 1), true).toCharArray();
             }
+        } else if (idx == 0) {
+            throw new IllegalArgumentException("The connection string contains an at-sign (@) without a user name");
         } else {
             hostIdentifier = userAndHostInformation;
         }
@@ -688,6 +693,9 @@ public class ConnectionString {
                     mechanism = AuthenticationMechanism.fromMechanismName(value);
                 }
             } else if (key.equals("authsource")) {
+                if (userName == null && !isSrvProtocol) {
+                    throw new IllegalArgumentException("A username is required when an authentication source is specified");
+                }
                 authSource = value;
             } else if (key.equals("gssapiservicename")) {
                 gssapiServiceName = value;

--- a/driver-core/src/test/resources/auth/connection-string.json
+++ b/driver-core/src/test/resources/auth/connection-string.json
@@ -352,9 +352,10 @@
       "credential": null
     },
     {
-      "description": "authSource without username is invalid (default mechanism)",
+      "description": "authSource without username doesn't create credential",
       "uri": "mongodb://localhost/?authSource=foo",
-      "valid": false
+      "valid": true,
+      "credential": null
     },
     {
       "description": "should throw an exception if no username provided (userinfo implies default mechanism)",

--- a/driver-core/src/test/resources/auth/connection-string.json
+++ b/driver-core/src/test/resources/auth/connection-string.json
@@ -3,101 +3,91 @@
     {
       "description": "should use the default source and mechanism",
       "uri": "mongodb://user:password@localhost",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "admin"
-      },
-      "options": null
+        "source": "admin",
+        "mechanism": null,
+        "mechanism_properties": null
+      }
     },
     {
       "description": "should use the database when no authSource is specified",
       "uri": "mongodb://user:password@localhost/foo",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "foo"
-      },
-      "options": null
+        "source": "foo",
+        "mechanism": null,
+        "mechanism_properties": null
+      }
     },
     {
       "description": "should use the authSource when specified",
       "uri": "mongodb://user:password@localhost/foo?authSource=bar",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "bar"
-      },
-      "options": null
+        "source": "bar",
+        "mechanism": null,
+        "mechanism_properties": null
+      }
     },
     {
       "description": "should recognise the mechanism (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user@DOMAIN.COM",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI"
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "mongodb"
+        }
       }
     },
     {
       "description": "should ignore the database (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/foo?authMechanism=GSSAPI",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user@DOMAIN.COM",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI"
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "mongodb"
+        }
       }
     },
     {
       "description": "should accept valid authSource (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=$external",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user@DOMAIN.COM",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI"
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "mongodb"
+        }
       }
     },
     {
       "description": "should accept generic mechanism property (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user@DOMAIN.COM",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI",
-        "authmechanismproperties": {
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
           "SERVICE_NAME": "other",
           "CANONICALIZE_HOST_NAME": true
         }
@@ -106,347 +96,275 @@
     {
       "description": "should accept the password (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM:password@localhost/?authMechanism=GSSAPI&authSource=$external",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user@DOMAIN.COM",
         "password": "password",
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI"
-      }
-    },
-    {
-      "description": "may support deprecated gssapiServiceName option (GSSAPI)",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&gssapiServiceName=other",
-      "hosts": null,
-      "valid": true,
-      "warning": false,
-      "auth": {
-        "username": "user@DOMAIN.COM",
-        "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "GSSAPI",
-        "authmechanismproperties": {
-          "SERVICE_NAME": "other"
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "mongodb"
         }
       }
     },
     {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should throw an exception if no username (GSSAPI)",
       "uri": "mongodb://localhost/?authMechanism=GSSAPI",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should recognize the mechanism (MONGODB-CR)",
       "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-CR",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "admin"
-      },
-      "options": {
-        "authmechanism": "MONGODB-CR"
+        "source": "admin",
+        "mechanism": "MONGODB-CR",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the database when no authSource is specified (MONGODB-CR)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "foo"
-      },
-      "options": {
-        "authmechanism": "MONGODB-CR"
+        "source": "foo",
+        "mechanism": "MONGODB-CR",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the authSource when specified (MONGODB-CR)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource=bar",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "bar"
-      },
-      "options": {
-        "authmechanism": "MONGODB-CR"
+        "source": "bar",
+        "mechanism": "MONGODB-CR",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should throw an exception if no username is supplied (MONGODB-CR)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-CR",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should recognize the mechanism (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "MONGODB-X509"
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should ignore the database (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/foo?authMechanism=MONGODB-X509",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "MONGODB-X509"
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should accept valid authSource (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509&authSource=$external",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "MONGODB-X509"
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should recognize the mechanism with no username (MONGODB-X509)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-X509",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": null,
         "password": null,
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "MONGODB-X509"
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should throw an exception if supplied a password (MONGODB-X509)",
       "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-X509",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should throw an exception if authSource is invalid (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/foo?authMechanism=MONGODB-X509&authSource=bar",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should recognize the mechanism (PLAIN)",
       "uri": "mongodb://user:password@localhost/?authMechanism=PLAIN",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "$external"
-      },
-      "options": {
-        "authmechanism": "PLAIN"
+        "source": "$external",
+        "mechanism": "PLAIN",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the database when no authSource is specified (PLAIN)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=PLAIN",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "foo"
-      },
-      "options": {
-        "authmechanism": "PLAIN"
+        "source": "foo",
+        "mechanism": "PLAIN",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the authSource when specified (PLAIN)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=PLAIN&authSource=bar",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "bar"
-      },
-      "options": {
-        "authmechanism": "PLAIN"
+        "source": "bar",
+        "mechanism": "PLAIN",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should throw an exception if no username (PLAIN)",
       "uri": "mongodb://localhost/?authMechanism=PLAIN",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should recognize the mechanism (SCRAM-SHA-1)",
       "uri": "mongodb://user:password@localhost/?authMechanism=SCRAM-SHA-1",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "admin"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-1"
+        "source": "admin",
+        "mechanism": "SCRAM-SHA-1",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the database when no authSource is specified (SCRAM-SHA-1)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=SCRAM-SHA-1",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "foo"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-1"
+        "source": "foo",
+        "mechanism": "SCRAM-SHA-1",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should accept valid authSource (SCRAM-SHA-1)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=SCRAM-SHA-1&authSource=bar",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "bar"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-1"
+        "source": "bar",
+        "mechanism": "SCRAM-SHA-1",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should throw an exception if no username (SCRAM-SHA-1)",
       "uri": "mongodb://localhost/?authMechanism=SCRAM-SHA-1",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
     },
     {
       "description": "should recognize the mechanism (SCRAM-SHA-256)",
       "uri": "mongodb://user:password@localhost/?authMechanism=SCRAM-SHA-256",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "admin"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-256"
+        "source": "admin",
+        "mechanism": "SCRAM-SHA-256",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should use the database when no authSource is specified (SCRAM-SHA-256)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=SCRAM-SHA-256",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "foo"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-256"
+        "source": "foo",
+        "mechanism": "SCRAM-SHA-256",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should accept valid authSource (SCRAM-SHA-256)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=SCRAM-SHA-256&authSource=bar",
-      "hosts": null,
       "valid": true,
-      "warning": false,
-      "auth": {
+      "credential": {
         "username": "user",
         "password": "password",
-        "db": "bar"
-      },
-      "options": {
-        "authmechanism": "SCRAM-SHA-256"
+        "source": "bar",
+        "mechanism": "SCRAM-SHA-256",
+        "mechanism_properties": null
       }
     },
     {
       "description": "should throw an exception if no username (SCRAM-SHA-256)",
       "uri": "mongodb://localhost/?authMechanism=SCRAM-SHA-256",
-      "hosts": null,
-      "valid": false,
-      "warning": false,
-      "auth": null,
-      "options": null
+      "valid": false
+    },
+    {
+      "description": "URI with no auth-related info doesn't create credential",
+      "uri": "mongodb://localhost/",
+      "valid": true,
+      "credential": null
+    },
+    {
+      "description": "database in URI path doesn't create credentials",
+      "uri": "mongodb://localhost/foo",
+      "valid": true,
+      "credential": null
+    },
+    {
+      "description": "authSource without username is invalid (default mechanism)",
+      "uri": "mongodb://localhost/?authSource=foo",
+      "valid": false
+    },
+    {
+      "description": "should throw an exception if no username provided (userinfo implies default mechanism)",
+      "uri": "mongodb://@localhost.com/",
+      "valid": false
+    },
+    {
+      "description": "should throw an exception if no username/password provided (userinfo implies default mechanism)",
+      "uri": "mongodb://:@localhost.com/",
+      "valid": false
     }
   ]
 }

--- a/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
@@ -123,6 +123,7 @@ public class AuthConnectionStringTest extends TestCase {
     private void assertMechanism(final String key, final String actual) {
         BsonValue expected = getExpectedValue(key);
 
+        // MONGODB-CR was removed from the AuthenticationMechanism enum for the 4.0 release, so null will be assigned.
         if (expected.isString() && expected.asString().getValue().equals("MONGODB-CR")) {
             assertNull(String.format("%s should be null when the expected mechanism is MONGODB-CR", key), actual);
         } else {

--- a/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
@@ -138,6 +138,9 @@ public class AuthConnectionStringTest extends TestCase {
             for (String key : document.keySet()) {
                 if (document.get(key).isString()) {
                     String expectedValue = document.getString(key).getValue();
+
+                    // If the mechanism is "GSSAPI", the default SERVICE_NAME, which is stated as "mongodb" in the specification,
+                    // is set to null in the driver.
                     if (credential.getMechanism().equals("GSSAPI") && key.equals("SERVICE_NAME") && expectedValue.equals("mongodb")) {
                         assertNull(credential.getMechanismProperty(key, null));
                     } else {

--- a/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
@@ -111,7 +111,7 @@ public class AuthConnectionStringTest extends TestCase {
         BsonValue expected = getExpectedValue(key);
 
         if (expected.isNull()) {
-            assertTrue(String.format("%s should be null", key), actual == null);
+            assertNull(String.format("%s should be null", key), actual);
         } else if (expected.isString()) {
             String expectedString = expected.asString().getValue();
             assertTrue(String.format("%s should be %s but was %s", key, actual, expectedString), actual.equals(expectedString));
@@ -124,7 +124,7 @@ public class AuthConnectionStringTest extends TestCase {
         BsonValue expected = getExpectedValue(key);
 
         if (expected.isString() && expected.asString().getValue().equals("MONGODB-CR")) {
-            assertTrue(String.format("%s should be null when the expected mechanism is MONGODB-CR", key), actual == null);
+            assertNull(String.format("%s should be null when the expected mechanism is MONGODB-CR", key), actual);
         } else {
             assertString(key, actual);
         }

--- a/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
@@ -30,7 +30,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 // See https://github.com/mongodb/specifications/tree/master/source/auth/tests
 @RunWith(Parameterized.class)
@@ -93,26 +92,14 @@ public class AuthConnectionStringTest extends TestCase {
         }
 
         MongoCredential credential = connectionString.getCredential();
-        assertString("auth.db", credential.getSource());
-        assertString("auth.username", credential.getUserName());
+        if (credential != null) {
+            assertString("credential.source", credential.getSource());
+            assertString("credential.username", credential.getUserName());
 
-        // Passwords for certain auth mechanisms are ignored.
-        String password = credential.getPassword() != null ? new String(credential.getPassword()) : null;
-        if (password != null) {
-            assertString("auth.password", password);
-        }
-        if (definition.get("options").isDocument()) {
-            for (Map.Entry<String, BsonValue> option : definition.getDocument("options").entrySet()) {
-                if (option.getKey().equals("authmechanism")) {
-                    String expected = option.getValue().asString().getValue();
-                    if (expected.equals("MONGODB-CR")) {
-                        assertNotNull(connectionString.getCredential());
-                        assertNull(connectionString.getCredential().getAuthenticationMechanism());
-                    } else {
-                        String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
-                        assertEquals(expected, actual);
-                    }
-                }
+            // Passwords for certain auth mechanisms are ignored.
+            String password = credential.getPassword() != null ? new String(credential.getPassword()) : null;
+            if (password != null) {
+                assertString("credential.password", password);
             }
         }
     }


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5ddda4b1e3c33123a4f08418