### PR TITLE
Add NPS Survey to all off-domain driver documentation

### DIFF
--- a/docs/landing/layouts/partials/assets/javascripts.html
+++ b/docs/landing/layouts/partials/assets/javascripts.html
@@ -5,3 +5,4 @@
 <script type="text/javascript" src="{{.Site.BaseURL}}/s/lib/bootstrap-toggle/bootstrap-toggle.min.js"></script>
 <script type="text/javascript" src="{{.Site.BaseURL}}/s/lib/zeroclipboard/ZeroClipboard.min.js"></script>
 <script type="text/javascript" src="{{.Site.BaseURL}}/s/js/frontpage.js"></script>
+<script type="text/javascript" src="{{.Site.BaseURL}}/s/lib/delighted.js"></script>

--- a/docs/landing/static/s/lib/delighted.js
+++ b/docs/landing/static/s/lib/delighted.js
@@ -1,0 +1,29 @@
+export function initialize() {
+    /* eslint-disable */
+    // Delighted
+    !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+    // Segment
+    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
+    }}();
+}
+export function setup(fastNav) {
+    try {
+        const sampleFactor = 0.1;
+        window.delighted.survey({
+            minTimeOnPage: 180,
+            sampleFactor: sampleFactor
+        });
+    } catch (err) {
+        console.error(err);
+    }
+    // Update Segment
+    try {
+        window.analytics.page({
+          path: location.pathname,
+          url: location.href
+        });
+    } catch (err) {
+        console.error(err);
+    }
+}

--- a/docs/landing/static/s/lib/delighted.js
+++ b/docs/landing/static/s/lib/delighted.js
@@ -1,29 +1,18 @@
-export function initialize() {
-    /* eslint-disable */
-    // Delighted
-    !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-    // Segment
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+/* eslint-disable */
+// Delighted
+!function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+// Segment
+!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
         analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
     }}();
-}
-export function setup(fastNav) {
-    try {
-        const sampleFactor = 0.1;
-        window.delighted.survey({
-            minTimeOnPage: 180,
-            sampleFactor: sampleFactor
-        });
-    } catch (err) {
-        console.error(err);
-    }
-    // Update Segment
-    try {
-        window.analytics.page({
-          path: location.pathname,
-          url: location.href
-        });
-    } catch (err) {
-        console.error(err);
-    }
-}
+
+delighted.survey({
+    minTimeOnPage: 180,
+    sampleFactor: 0.1
+});
+
+// Update Segment
+analytics.page({
+    path: location.pathname,
+    url: location.href
+});

--- a/docs/reference/themes/mongodb/layouts/partials/assets/javascripts.html
+++ b/docs/reference/themes/mongodb/layouts/partials/assets/javascripts.html
@@ -12,5 +12,5 @@
 <script type="text/javascript" src="{{.Site.BaseURL}}/js/navbar.js"></script>
 <script type="text/javascript" src="{{.Site.BaseURL}}/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="{{.Site.BaseURL}}/js/scripts.js"></script>
-{{ partial "assets/javascriptExtras.html" . }}
 <script type="text/javascript" src="{{.Site.BaseURL}}/lib/delighted.js"></script>
+{{ partial "assets/javascriptExtras.html" . }}

--- a/docs/reference/themes/mongodb/layouts/partials/assets/javascripts.html
+++ b/docs/reference/themes/mongodb/layouts/partials/assets/javascripts.html
@@ -13,3 +13,4 @@
 <script type="text/javascript" src="{{.Site.BaseURL}}/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="{{.Site.BaseURL}}/js/scripts.js"></script>
 {{ partial "assets/javascriptExtras.html" . }}
+<script type="text/javascript" src="{{.Site.BaseURL}}/lib/delighted.js"></script>

--- a/docs/reference/themes/mongodb/static/lib/delighted.js
+++ b/docs/reference/themes/mongodb/static/lib/delighted.js
@@ -1,29 +1,19 @@
-export function initialize() {
-    /* eslint-disable */
-    // Delighted
-    !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-    // Segment
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+/* eslint-disable */
+// Delighted
+!function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+
+// Segment
+!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
         analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
     }}();
-}
-export function setup(fastNav) {
-    try {
-        const sampleFactor = 0.1;
-        window.delighted.survey({
-            minTimeOnPage: 180,
-            sampleFactor: sampleFactor
-        });
-    } catch (err) {
-        console.error(err);
-    }
-    // Update Segment
-    try {
-        window.analytics.page({
-          path: location.pathname,
-          url: location.href
-        });
-    } catch (err) {
-        console.error(err);
-    }
-}
+
+delighted.survey({
+    minTimeOnPage: 180,
+    sampleFactor: 0.1
+});
+
+// Update Segment
+analytics.page({
+    path: location.pathname,
+    url: location.href
+});

--- a/docs/reference/themes/mongodb/static/lib/delighted.js
+++ b/docs/reference/themes/mongodb/static/lib/delighted.js
@@ -1,0 +1,29 @@
+export function initialize() {
+    /* eslint-disable */
+    // Delighted
+    !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+    // Segment
+    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
+    }}();
+}
+export function setup(fastNav) {
+    try {
+        const sampleFactor = 0.1;
+        window.delighted.survey({
+            minTimeOnPage: 180,
+            sampleFactor: sampleFactor
+        });
+    } catch (err) {
+        console.error(err);
+    }
+    // Update Segment
+    try {
+        window.analytics.page({
+          path: location.pathname,
+          url: location.href
+        });
+    } catch (err) {
+        console.error(err);
+    }
+}


### PR DESCRIPTION
JAVA-3523

I tested these changes first by using the JavaScript file `delighted_snippet.js` found in the [DRIVERS-769](https://jira.mongodb.org/browse/DRIVERS-769) ticket. Using this snippet ensured that the survey would appear anytime I appended `?delighted=test` to the URL. Once I could see the survey for all documentation pages using `?delighted=test`, I substituted the code in the `delighted.js` files to use the code from the attached file `docs_delighted_implementation.js` in the DRIVERS ticket. Since the enhanced JavaScript code only shows the survey once every 30 days, and only if a user has been on the site for more than 3 minutes, this was a bit harder to test.

I tested these changes locally using `hugo`. 

We can debate the location of the new JavaScript files, as well as the durations used in the enhanced JavaScript code, if necessary.