### PR TITLE
Change uri_options/auth-options spec test to enable conditional tests

### DIFF
--- a/driver-core/src/test/resources/uri-options/auth-options.json
+++ b/driver-core/src/test/resources/uri-options/auth-options.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "description": "Valid auth options are parsed correctly",
+      "description": "Valid auth options are parsed correctly (GSSAPI)",
       "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
       "valid": true,
       "warning": false,
@@ -14,6 +14,18 @@
           "CANONICALIZE_HOST_NAME": true
         },
         "authSource": "$external"
+      }
+    },
+    {
+      "description": "Valid auth options are parsed correctly (SCRAM-SHA-1)",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=SCRAM-SHA-1&authSource=authSourceDB",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "authMechanism": "SCRAM-SHA-1",
+        "authSource": "authSourceDB"
       }
     }
   ]


### PR DESCRIPTION
JAVA-3558

Evergreen patch: https://evergreen.mongodb.com/version/5e04d61fa4cf474c8d645f98
Note: Failing tests are due to either metaTextScore or a retryable writes test in reactive streams.