### PR TITLE
Revert Handle NPE caused by SingleResultCallback based Observables

### DIFF
--- a/driver-scala/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
@@ -95,10 +95,7 @@ trait ObservableImplicits {
             subscription.request(1)
           }
 
-          override def onError(throwable: Throwable): Unit = throwable match {
-            case npe: NullPointerException => onComplete()
-            case _                         => completeWith("onError", () => observer.onError(throwable))
-          }
+          override def onError(throwable: Throwable): Unit = completeWith("onError", () => observer.onError(throwable))
 
           override def onComplete(): Unit = {
             completeWith("onComplete", { () =>


### PR DESCRIPTION
JAVA-3570

Evergreen patch: https://evergreen.mongodb.com/version/5e052f8d57e85a5468609e20