### PR TITLE
Remove Gradle deprecation warnings

### DIFF
--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -18,7 +18,7 @@ description = "A Scala wrapper / extension to the bson library"
 archivesBaseName = 'mongo-scala-bson'
 
 dependencies {
-    compile project(path: ':bson', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
 }
 
 sourceSets {

--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -18,7 +18,7 @@ description = "A Scala wrapper / extension to the bson library"
 archivesBaseName = 'mongo-scala-bson'
 
 dependencies {
-    api project(path: ':bson', configuration: 'default')
+    compile project(path: ':bson', configuration: 'default')
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ configure(scalaProjects) {
     apply plugin: 'idea'
     apply plugin: "com.adtran.scala-multiversion-plugin"
     apply plugin: "com.diffplug.gradle.spotless"
+    apply plugin: 'java-library'
 
     group = 'org.mongodb.scala'
 
@@ -100,14 +101,14 @@ configure(scalaProjects) {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     dependencies {
-        compile ('org.scala-lang:scala-library:%scala-version%')
-        compile ('org.scala-lang:scala-reflect:%scala-version%')
+        implementation ('org.scala-lang:scala-library:%scala-version%')
+        implementation ('org.scala-lang:scala-reflect:%scala-version%')
 
-        testCompile('junit:junit:4.12')
-        testCompile('org.scalatest:scalatest_%%:3.0.8')
-        testCompile('org.scalamock:scalamock_%%:4.4.0')
-        testCompile('ch.qos.logback:logback-classic:1.1.3')
-        testCompile('org.reflections:reflections:0.9.10')
+        testImplementation('junit:junit:4.12')
+        testImplementation('org.scalatest:scalatest_%%:3.0.8')
+        testImplementation('org.scalamock:scalamock_%%:4.4.0')
+        testImplementation('ch.qos.logback:logback-classic:1.1.3')
+        testImplementation('org.reflections:reflections:0.9.10')
     }
     
 
@@ -134,8 +135,8 @@ configure(javaMainProjects) {
 
     dependencies {
         compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
-        compile 'org.slf4j:slf4j-api:1.7.6', optional
-        testCompile 'com.google.code.findbugs:jsr305:1.3.9'
+        implementation 'org.slf4j:slf4j-api:1.7.6', optional
+        testImplementation 'com.google.code.findbugs:jsr305:1.3.9'
     }
 
     /* Compiling */
@@ -155,13 +156,13 @@ configure(javaCodeCheckedProjects) {
     apply plugin: 'codenarc'
 
     dependencies {
-        testCompile 'org.codehaus.groovy:groovy-all:2.4.15'
-        testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
-        testCompile 'cglib:cglib-nodep:2.2.2'
-        testCompile 'org.objenesis:objenesis:1.3'
-        testCompile 'org.hamcrest:hamcrest-all:1.3'
-        testCompile 'ch.qos.logback:logback-classic:1.1.1'
-        testCompile project(':util') //Adding categories to classpath
+        testImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
+        testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
+        testImplementation 'cglib:cglib-nodep:2.2.2'
+        testImplementation 'org.objenesis:objenesis:1.3'
+        testImplementation 'org.hamcrest:hamcrest-all:1.3'
+        testImplementation 'ch.qos.logback:logback-classic:1.1.1'
+        testImplementation project(':util') //Adding categories to classpath
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         
         // Scala plugins
         classpath "com.adtran:scala-multiversion-plugin:1.0.35"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.24.2"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ configure(scalaProjects) {
     apply plugin: 'idea'
     apply plugin: "com.adtran.scala-multiversion-plugin"
     apply plugin: "com.diffplug.gradle.spotless"
-    apply plugin: 'java-library'
 
     group = 'org.mongodb.scala'
 
@@ -101,8 +100,8 @@ configure(scalaProjects) {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     dependencies {
-        implementation ('org.scala-lang:scala-library:%scala-version%')
-        implementation ('org.scala-lang:scala-reflect:%scala-version%')
+        compile ('org.scala-lang:scala-library:%scala-version%')
+        compile ('org.scala-lang:scala-reflect:%scala-version%')
 
         testImplementation('junit:junit:4.12')
         testImplementation('org.scalatest:scalatest_%%:3.0.8')
@@ -132,10 +131,11 @@ configure(scalaProjects) {
 
 configure(javaMainProjects) {
     apply plugin: 'nebula.optional-base'
-
+    apply plugin: 'java-library'
+    
     dependencies {
         compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
-        implementation 'org.slf4j:slf4j-api:1.7.6', optional
+        api 'org.slf4j:slf4j-api:1.7.6', optional
         testImplementation 'com.google.code.findbugs:jsr305:1.3.9'
     }
 

--- a/driver-benchmarks/build.gradle
+++ b/driver-benchmarks/build.gradle
@@ -30,8 +30,8 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':driver-sync')
-    compile 'ch.qos.logback:logback-classic:1.1.1'
+    api project(':driver-sync')
+    implementation 'ch.qos.logback:logback-classic:1.1.1'
 }
 
 javadoc {

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -33,13 +33,13 @@ sourceSets.main.resources.srcDirs = ['src/resources']
 dependencies {
     api project(path: ':bson', configuration: 'default')
 
-    implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
-    implementation "io.netty:netty-buffer:$nettyVersion", optional
-    implementation "io.netty:netty-transport:$nettyVersion", optional
-    implementation "io.netty:netty-handler:$nettyVersion", optional
-    implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
-    implementation "com.github.luben:zstd-jni:$zstdVersion", optional
-    implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
+    api "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
+    api "io.netty:netty-buffer:$nettyVersion", optional
+    api "io.netty:netty-transport:$nettyVersion", optional
+    api "io.netty:netty-handler:$nettyVersion", optional
+    api "org.xerial.snappy:snappy-java:$snappyVersion", optional
+    api "com.github.luben:zstd-jni:$zstdVersion", optional
+    api "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
 
     testImplementation project(':bson').sourceSets.test.output
 }

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     api project(path: ':bson', configuration: 'default')
 
     implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
-    implementation "io.netty:netty-buffer:$nettyVersion", optional
-    implementation "io.netty:netty-transport:$nettyVersion", optional
+    api "io.netty:netty-buffer:$nettyVersion", optional
+    api "io.netty:netty-transport:$nettyVersion", optional
     implementation "io.netty:netty-handler:$nettyVersion", optional
     implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
     implementation "com.github.luben:zstd-jni:$zstdVersion", optional

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -33,13 +33,13 @@ sourceSets.main.resources.srcDirs = ['src/resources']
 dependencies {
     api project(path: ':bson', configuration: 'default')
 
-    api "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
-    api "io.netty:netty-buffer:$nettyVersion", optional
-    api "io.netty:netty-transport:$nettyVersion", optional
-    api "io.netty:netty-handler:$nettyVersion", optional
-    api "org.xerial.snappy:snappy-java:$snappyVersion", optional
-    api "com.github.luben:zstd-jni:$zstdVersion", optional
-    api "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
+    implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
+    implementation "io.netty:netty-buffer:$nettyVersion", optional
+    implementation "io.netty:netty-transport:$nettyVersion", optional
+    implementation "io.netty:netty-handler:$nettyVersion", optional
+    implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
+    implementation "com.github.luben:zstd-jni:$zstdVersion", optional
+    implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
 
     testImplementation project(':bson').sourceSets.test.output
 }

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -31,17 +31,17 @@ ext {
 sourceSets.main.resources.srcDirs = ['src/resources']
 
 dependencies {
-    compile project(path: ':bson', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
 
-    compile "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
-    compile "io.netty:netty-buffer:$nettyVersion", optional
-    compile "io.netty:netty-transport:$nettyVersion", optional
-    compile "io.netty:netty-handler:$nettyVersion", optional
-    compile "org.xerial.snappy:snappy-java:$snappyVersion", optional
-    compile "com.github.luben:zstd-jni:$zstdVersion", optional
-    compile "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
+    implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
+    implementation "io.netty:netty-buffer:$nettyVersion", optional
+    implementation "io.netty:netty-transport:$nettyVersion", optional
+    implementation "io.netty:netty-handler:$nettyVersion", optional
+    implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
+    implementation "com.github.luben:zstd-jni:$zstdVersion", optional
+    implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
 
-    testCompile project(':bson').sourceSets.test.output
+    testImplementation project(':bson').sourceSets.test.output
 }
 
 buildConfig {

--- a/driver-legacy/build.gradle
+++ b/driver-legacy/build.gradle
@@ -30,11 +30,11 @@ test {
 }
 
 dependencies {
-    compile project(':bson')
-    compile project(':driver-core')
-    compile project(':driver-sync')
+    api project(':bson')
+    api project(':driver-core')
+    api project(':driver-sync')
 
-    testCompile project(':bson').sourceSets.test.output
-    testCompile project(':driver-core').sourceSets.test.output
-    testCompile project(':driver-sync').sourceSets.test.output
+    testImplementation project(':bson').sourceSets.test.output
+    testImplementation project(':driver-core').sourceSets.test.output
+    testImplementation project(':driver-sync').sourceSets.test.output
 }

--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -18,16 +18,16 @@ description = "A Reactive Streams implementation of the MongoDB Java driver"
 archivesBaseName = 'mongodb-driver-reactivestreams'
 
 dependencies {
-    compile project(path: ':bson', configuration: 'default')
-    compile project(path: ':driver-core', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
+    api project(path: ':driver-core', configuration: 'default')
 
-    compile 'org.reactivestreams:reactive-streams:1.0.2'
+    implementation 'org.reactivestreams:reactive-streams:1.0.2'
 
-    testCompile project(':bson').sourceSets.test.output
-    testCompile project(':driver-sync')
-    testCompile project(':driver-sync').sourceSets.test.output
-    testCompile project(':driver-core').sourceSets.test.output
-    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.2'
+    testImplementation project(':bson').sourceSets.test.output
+    testImplementation project(':driver-sync')
+    testImplementation project(':driver-sync').sourceSets.test.output
+    testImplementation project(':driver-core').sourceSets.test.output
+    testImplementation 'org.reactivestreams:reactive-streams-tck:1.0.2'
 }
 
 sourceSets {

--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     api project(path: ':bson', configuration: 'default')
     api project(path: ':driver-core', configuration: 'default')
 
-    implementation 'org.reactivestreams:reactive-streams:1.0.2'
+    api 'org.reactivestreams:reactive-streams:1.0.2'
 
     testImplementation project(':bson').sourceSets.test.output
     testImplementation project(':driver-sync')

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -18,13 +18,13 @@ description = "A Scala wrapper / extension to the bson library"
 archivesBaseName = 'mongo-scala-driver'
 
 dependencies {
-    api project(path: ':bson', configuration: 'default')
-    api project(path: ':bson-scala', configuration: 'default')
-    api project(path: ':driver-core', configuration: 'default')
-    implementation project(path: ':driver-reactive-streams', configuration: 'default')
-    implementation project(path: ':driver-sync', configuration: 'default')
+    compile project(path: ':bson', configuration: 'default')
+    compile project(path: ':bson-scala', configuration: 'default')
+    compile project(path: ':driver-core', configuration: 'default')
+    compile project(path: ':driver-reactive-streams', configuration: 'default')
+    compile project(path: ':driver-sync', configuration: 'default')
 
-    implementation 'org.reactivestreams:reactive-streams:1.0.2'
+    compile 'org.reactivestreams:reactive-streams:1.0.2'
 
     testImplementation project(':util')
     testImplementation project(':driver-sync')

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -18,24 +18,24 @@ description = "A Scala wrapper / extension to the bson library"
 archivesBaseName = 'mongo-scala-driver'
 
 dependencies {
-    compile project(path: ':bson', configuration: 'default')
-    compile project(path: ':bson-scala', configuration: 'default')
-    compile project(path: ':driver-core', configuration: 'default')
-    compile project(path: ':driver-reactive-streams', configuration: 'default')
-    compile project(path: ':driver-sync', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
+    api project(path: ':bson-scala', configuration: 'default')
+    api project(path: ':driver-core', configuration: 'default')
+    implementation project(path: ':driver-reactive-streams', configuration: 'default')
+    implementation project(path: ':driver-sync', configuration: 'default')
 
-    compile 'org.reactivestreams:reactive-streams:1.0.2'
+    implementation 'org.reactivestreams:reactive-streams:1.0.2'
 
-    testCompile project(':util')
-    testCompile project(':driver-sync')
-    testCompile project(':bson').sourceSets.test.output
-    testCompile project(':driver-sync').sourceSets.test.output
-    testCompile project(':driver-core').sourceSets.test.output
+    testImplementation project(':util')
+    testImplementation project(':driver-sync')
+    testImplementation project(':bson').sourceSets.test.output
+    testImplementation project(':driver-sync').sourceSets.test.output
+    testImplementation project(':driver-core').sourceSets.test.output
 }
 
 
 configurations {
-    integrationTestCompile.extendsFrom testCompile
+    integrationTestCompile.extendsFrom testImplementation
     integrationTestRuntime.extendsFrom testRuntime
 }
 

--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -21,11 +21,11 @@ ext {
 }
 
 dependencies {
-    compile project(path: ':bson', configuration: 'default')
-    compile project(path: ':driver-core', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
+    api project(path: ':driver-core', configuration: 'default')
 
-    testCompile project(':bson').sourceSets.test.output
-    testCompile project(':driver-core').sourceSets.test.output
+    testImplementation project(':bson').sourceSets.test.output
+    testImplementation project(':driver-core').sourceSets.test.output
 }
 
 sourceSets {

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -33,26 +33,25 @@ task docs(type: Javadoc) {
 
 def utilProject = project(':util')
 allprojects {
-    afterEvaluate { project ->
-        tasks.withType(Javadoc) {
-            dependsOn utilProject.compileJava //We need taglets to be compiled
-            exclude "**/com/mongodb/**/benchmark/**"
-            exclude "**/com/mongodb/**/internal/**"
-            exclude "**/org/bson/**/internal/**"
-            options {
-                author = true
-                version = true
-                links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
-                tagletPath single(utilProject.sourceSets.main.output.classesDirs)
-                taglets 'ManualTaglet'
-                taglets 'DochubTaglet'
-                taglets 'ServerReleaseTaglet'
-                encoding = 'UTF-8'
-                charSet 'UTF-8'
-                docEncoding 'UTF-8'
-                addBooleanOption("html5", true)
-                addBooleanOption("-allow-script-in-comments", true)
-                header = '''
+    tasks.withType(Javadoc) {
+        dependsOn utilProject.compileJava //We need taglets to be compiled
+        exclude "**/com/mongodb/**/benchmark/**"
+        exclude "**/com/mongodb/**/internal/**"
+        exclude "**/org/bson/**/internal/**"
+        options {
+            author = true
+            version = true
+            links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
+            tagletPath single(utilProject.sourceSets.main.output.classesDirs)
+            taglets 'ManualTaglet'
+            taglets 'DochubTaglet'
+            taglets 'ServerReleaseTaglet'
+            encoding = 'UTF-8'
+            charSet 'UTF-8'
+            docEncoding 'UTF-8'
+            addBooleanOption("html5", true)
+            addBooleanOption("-allow-script-in-comments", true)
+            header = '''
                     | <script type="text/javascript">
                     | function setLocationHash() {
                     |   try {
@@ -90,7 +89,6 @@ allprojects {
                     | setSearchUrlPrefix();
                     |
                     | </script>'''.stripMargin()
-            }
         }
     }
 }


### PR DESCRIPTION
JAVA-3574

Evergreen patch: https://evergreen.mongodb.com/version/5e1e4f241e2d177ea65204e9

The Gradle changes here produce no differences between the JAR files generated on the master branch and on this branch. The only Gradle 7 deprecation warnings remaining come from one plugin, `spotbugs-gradle-plugin`. I have created ticket JAVA-3590 to address this.