### PR TITLE
Support ability to pass hint to updates

### DIFF
--- a/bson/src/test/resources/bson/double.json
+++ b/bson/src/test/resources/bson/double.json
@@ -28,16 +28,16 @@
             "relaxed_extjson": "{\"d\" : -1.0001220703125}"
         },
         {
-            "description": "1.23456789012345677E18",
-            "canonical_bson": "1000000001640081E97DF41022B14300",
-            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"1.23456789012345677E18\"}}",
-            "relaxed_extjson": "{\"d\" : 1.23456789012345677E18}"
+            "description": "1.2345678921232E18",
+            "canonical_bson": "100000000164002a1bf5f41022b14300",
+            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"1.2345678921232E18\"}}",
+            "relaxed_extjson": "{\"d\" : 1.2345678921232E18}"
         },
         {
-            "description": "-1.23456789012345677E18",
-            "canonical_bson": "1000000001640081E97DF41022B1C300",
-            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"-1.23456789012345677E18\"}}",
-            "relaxed_extjson": "{\"d\" : -1.23456789012345677E18}"
+            "description": "-1.2345678921232E18",
+            "canonical_bson": "100000000164002a1bf5f41022b1c300",
+            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"-1.2345678921232E18\"}}",
+            "relaxed_extjson": "{\"d\" : -1.2345678921232E18}"
         },
         {
             "description": "0.0",

--- a/docs/landing/data/releases.toml
+++ b/docs/landing/data/releases.toml
@@ -1,4 +1,4 @@
-current = "3.12.0"
+current = "3.12.1"
 
 [[versions]]
   version = "4.0.0-beta1"
@@ -6,7 +6,7 @@ current = "3.12.0"
   api = "./4.0/apidocs"
 
 [[versions]]
-  version = "3.12.0"
+  version = "3.12.1"
   status = "current"
   docs = "./3.12"
   api = "./3.12/javadoc"

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -693,6 +693,9 @@ public class ConnectionString {
                     mechanism = AuthenticationMechanism.fromMechanismName(value);
                 }
             } else if (key.equals("authsource")) {
+                if (value.equals("")) {
+                    throw new IllegalArgumentException("authSource can not be an empty string");
+                }
                 authSource = value;
             } else if (key.equals("gssapiservicename")) {
                 gssapiServiceName = value;

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -424,6 +424,18 @@ public final class Aggregates {
     }
 
     /**
+     * Creates a $out pipeline stage that writes out to the specified destination
+     *
+     * @param destination the destination details
+     * @return the $out pipeline stage
+     * @mongodb.driver.manual reference/operator/aggregation/out/  $out
+     * @since 4.1
+     */
+    public static Bson out(final Bson destination) {
+        return new SimplePipelineStage("$out", destination);
+    }
+
+    /**
      * Creates a $merge pipeline stage that merges into the specified collection
      *
      * @param collectionName the name of the collection to merge into

--- a/driver-core/src/main/com/mongodb/client/model/FindOneAndReplaceOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOneAndReplaceOptions.java
@@ -38,6 +38,8 @@ public class FindOneAndReplaceOptions {
     private long maxTimeMS;
     private Boolean bypassDocumentValidation;
     private Collation collation;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Gets a document describing the fields to return for all matching documents.
@@ -200,6 +202,52 @@ public class FindOneAndReplaceOptions {
         return this;
     }
 
+    /**
+     * Returns the hint for which index to use. The default is not to set a hint.
+     *
+     * @return the hint
+     * @since 4.1
+     */
+    @Nullable
+    public Bson getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     * @since 4.1
+     */
+    public FindOneAndReplaceOptions hint(@Nullable final Bson hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Gets the hint string to apply.
+     *
+     * @return the hint string, which should be the name of an existing index
+     * @since 4.1
+     */
+    @Nullable
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public FindOneAndReplaceOptions hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "FindOneAndReplaceOptions{"
@@ -210,6 +258,8 @@ public class FindOneAndReplaceOptions {
                 + ", maxTimeMS=" + maxTimeMS
                 + ", bypassDocumentValidation=" + bypassDocumentValidation
                 + ", collation=" + collation
+                + ", hint=" + hint
+                + ", hintString" + hintString
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/FindOneAndUpdateOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOneAndUpdateOptions.java
@@ -40,6 +40,8 @@ public class FindOneAndUpdateOptions {
     private Boolean bypassDocumentValidation;
     private Collation collation;
     private List<? extends Bson> arrayFilters;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Gets a document describing the fields to return for all matching documents.
@@ -227,6 +229,52 @@ public class FindOneAndUpdateOptions {
         return arrayFilters;
     }
 
+    /**
+     * Returns the hint for which index to use. The default is not to set a hint.
+     *
+     * @return the hint
+     * @since 4.1
+     */
+    @Nullable
+    public Bson getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     * @since 4.1
+     */
+    public FindOneAndUpdateOptions hint(@Nullable final Bson hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Gets the hint string to apply.
+     *
+     * @return the hint string, which should be the name of an existing index
+     * @since 4.1
+     */
+    @Nullable
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public FindOneAndUpdateOptions hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "FindOneAndUpdateOptions{"
@@ -238,6 +286,8 @@ public class FindOneAndUpdateOptions {
                 + ", bypassDocumentValidation=" + bypassDocumentValidation
                 + ", collation=" + collation
                 + ", arrayFilters=" + arrayFilters
+                + ", hint=" + hint
+                + ", hintString=" + hintString
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
@@ -17,7 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.lang.Nullable;
-import org.bson.BsonValue;
+import org.bson.conversions.Bson;
 
 /**
  * The options to apply when replacing documents.
@@ -31,7 +31,8 @@ public class ReplaceOptions {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
     private Collation collation;
-    private BsonValue hint;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Returns true if a new document should be inserted if there are no matches to the query filter.  The default is false.
@@ -101,27 +102,48 @@ public class ReplaceOptions {
     }
 
     /**
-     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Returns the hint for which index to use. The default is not to set a hint.
      *
-     * @return the hint, which may be null
+     * @return the hint
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
     @Nullable
-    public BsonValue getHint() {
+    public Bson getHint() {
         return hint;
     }
 
     /**
-     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Sets the hint for which index to use. A null value means no hint is set.
      *
-     * @param hint the hint, which may be null
+     * @param hint the hint
      * @return this
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
-    public ReplaceOptions hint(@Nullable final BsonValue hint) {
+    public ReplaceOptions hint(@Nullable final Bson hint) {
         this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Gets the hint string to apply.
+     *
+     * @return the hint string, which should be the name of an existing index
+     * @since 4.1
+     */
+    @Nullable
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public ReplaceOptions hintString(@Nullable final String hint) {
+        this.hintString = hint;
         return this;
     }
 
@@ -132,6 +154,7 @@ public class ReplaceOptions {
                 + ", bypassDocumentValidation=" + bypassDocumentValidation
                 + ", collation=" + collation
                 + ", hint=" + hint
+                + ", hintString=" + hintString
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.lang.Nullable;
+import org.bson.BsonValue;
 
 /**
  * The options to apply when replacing documents.
@@ -30,6 +31,7 @@ public class ReplaceOptions {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
     private Collation collation;
+    private BsonValue hint;
 
     /**
      * Returns true if a new document should be inserted if there are no matches to the query filter.  The default is false.
@@ -98,12 +100,38 @@ public class ReplaceOptions {
         return this;
     }
 
+    /**
+     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @return the hint, which may be null
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    @Nullable
+    public BsonValue getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @param hint the hint, which may be null
+     * @return this
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    public ReplaceOptions hint(@Nullable final BsonValue hint) {
+        this.hint = hint;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ReplaceOptions{"
                 + "upsert=" + upsert
                 + ", bypassDocumentValidation=" + bypassDocumentValidation
                 + ", collation=" + collation
+                + ", hint=" + hint
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/UpdateOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/UpdateOptions.java
@@ -17,7 +17,6 @@
 package com.mongodb.client.model;
 
 import com.mongodb.lang.Nullable;
-import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 
 import java.util.List;
@@ -35,7 +34,8 @@ public class UpdateOptions {
     private Boolean bypassDocumentValidation;
     private Collation collation;
     private List<? extends Bson> arrayFilters;
-    private BsonValue hint;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Returns true if a new document should be inserted if there are no matches to the query filter.  The default is false.
@@ -134,28 +134,49 @@ public class UpdateOptions {
     }
 
     /**
-     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Returns the hint for which index to use. The default is not to set a hint.
      *
-     * @param hint the hint, which may be null
+     * @return the hint
+     * @since 4.1
+     */
+    @Nullable
+    public Bson getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
      * @return this
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
-    public UpdateOptions hint(@Nullable final BsonValue hint) {
+    public UpdateOptions hint(@Nullable final Bson hint) {
         this.hint = hint;
         return this;
     }
 
     /**
-     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Gets the hint string to apply.
      *
-     * @return the hint, which may be null
+     * @return the hint string, which should be the name of an existing index
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
     @Nullable
-    public BsonValue getHint() {
-        return hint;
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public UpdateOptions hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
     }
 
     @Override
@@ -166,6 +187,7 @@ public class UpdateOptions {
                 + ", collation=" + collation
                 + ", arrayFilters=" + arrayFilters
                 + ", hint=" + hint
+                + ", hintString=" + hintString
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/UpdateOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/UpdateOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.lang.Nullable;
+import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 
 import java.util.List;
@@ -34,6 +35,7 @@ public class UpdateOptions {
     private Boolean bypassDocumentValidation;
     private Collation collation;
     private List<? extends Bson> arrayFilters;
+    private BsonValue hint;
 
     /**
      * Returns true if a new document should be inserted if there are no matches to the query filter.  The default is false.
@@ -131,6 +133,31 @@ public class UpdateOptions {
         return arrayFilters;
     }
 
+    /**
+     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @param hint the hint, which may be null
+     * @return this
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    public UpdateOptions hint(@Nullable final BsonValue hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @return the hint, which may be null
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    @Nullable
+    public BsonValue getHint() {
+        return hint;
+    }
+
     @Override
     public String toString() {
         return "UpdateOptions{"
@@ -138,6 +165,7 @@ public class UpdateOptions {
                 + ", bypassDocumentValidation=" + bypassDocumentValidation
                 + ", collation=" + collation
                 + ", arrayFilters=" + arrayFilters
+                + ", hint=" + hint
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/ServerDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerDescription.java
@@ -61,7 +61,7 @@ public class ServerDescription {
      * The maximum supported driver wire version
      * @since 3.8
      */
-    public static final int MAX_DRIVER_WIRE_VERSION = 8;
+    public static final int MAX_DRIVER_WIRE_VERSION = 9;
 
     private static final int DEFAULT_MAX_DOCUMENT_SIZE = 0x1000000;  // 16MB
 

--- a/driver-core/src/main/com/mongodb/internal/async/client/AsyncAggregateIterableImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/AsyncAggregateIterableImpl.java
@@ -84,8 +84,8 @@ class AsyncAggregateIterableImpl<TDocument, TResult> extends AsyncMongoIterableI
 
     @Override
     public void toCollection(final SingleResultCallback<Void> callback) {
-
-        if (getOutNamespace() == null) {
+        BsonDocument lastPipelineStage = getLastPipelineStage();
+        if (lastPipelineStage == null || !lastPipelineStage.containsKey("$out") && !lastPipelineStage.containsKey("$merge")) {
             throw new IllegalStateException("The last stage of the aggregation pipeline must be $out or $merge");
         }
 
@@ -169,17 +169,28 @@ class AsyncAggregateIterableImpl<TDocument, TResult> extends AsyncMongoIterableI
     }
 
     @Nullable
+    private BsonDocument getLastPipelineStage() {
+        if (pipeline.isEmpty()) {
+            return null;
+        } else {
+            Bson lastStage = notNull("last pipeline stage", pipeline.get(pipeline.size() - 1));
+            return lastStage.toBsonDocument(documentClass, codecRegistry);
+        }
+    }
+
+    @Nullable
     private MongoNamespace getOutNamespace() {
-        if (pipeline.size() == 0) {
+        BsonDocument lastPipelineStage = getLastPipelineStage();
+        if (lastPipelineStage == null) {
             return null;
         }
-
-        Bson lastStage = notNull("last stage", pipeline.get(pipeline.size() - 1));
-        BsonDocument lastStageDocument = lastStage.toBsonDocument(documentClass, codecRegistry);
-        if (lastStageDocument.containsKey("$out")) {
-            return new MongoNamespace(namespace.getDatabaseName(), lastStageDocument.getString("$out").getValue());
-        } else if (lastStageDocument.containsKey("$merge")) {
-            BsonDocument mergeDocument = lastStageDocument.getDocument("$merge");
+        if (lastPipelineStage.containsKey("$out")) {
+            if (!lastPipelineStage.get("$out").isString()) {
+                throw new IllegalStateException("Cannot return a cursor when the value for $out stage is not a string");
+            }
+            return new MongoNamespace(namespace.getDatabaseName(), lastPipelineStage.getString("$out").getValue());
+        } else if (lastPipelineStage.containsKey("$merge")) {
+            BsonDocument mergeDocument = lastPipelineStage.getDocument("$merge");
             if (mergeDocument.isDocument("into")) {
                 BsonDocument intoDocument = mergeDocument.getDocument("into");
                 return new MongoNamespace(intoDocument.getString("db", new BsonString(namespace.getDatabaseName())).getValue(),

--- a/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
@@ -37,6 +37,7 @@ public final class UpdateRequest extends WriteRequest {
     private boolean isUpsert = false;
     private Collation collation;
     private List<BsonDocument> arrayFilters;
+    private BsonValue hint;
 
     /**
      * Construct a new instance.
@@ -171,6 +172,30 @@ public final class UpdateRequest extends WriteRequest {
      */
     public List<BsonDocument> getArrayFilters() {
         return arrayFilters;
+    }
+
+    /**
+     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @param hint the hint, which may be null
+     * @return this
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    public UpdateRequest hint(final BsonValue hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     *
+     * @return the hint, which may be null
+     * @since 4.1
+     * @mongodb.server.release 4.2
+     */
+    public BsonValue getHint() {
+        return hint;
     }
 }
 

--- a/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.bulk;
 import com.mongodb.client.model.Collation;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
+import org.bson.conversions.Bson;
 
 import java.util.List;
 
@@ -37,7 +38,8 @@ public final class UpdateRequest extends WriteRequest {
     private boolean isUpsert = false;
     private Collation collation;
     private List<BsonDocument> arrayFilters;
-    private BsonValue hint;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Construct a new instance.
@@ -175,27 +177,47 @@ public final class UpdateRequest extends WriteRequest {
     }
 
     /**
-     * Sets the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Returns the hint for which index to use. The default is not to set a hint.
      *
-     * @param hint the hint, which may be null
+     * @return the hint
+     * @since 4.1
+     */
+    public Bson getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
      * @return this
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
-    public UpdateRequest hint(final BsonValue hint) {
+    public UpdateRequest hint(final Bson hint) {
         this.hint = hint;
         return this;
     }
 
     /**
-     * Returns the hint option - a document or string that specifies the index to use to support the query predicate.
+     * Gets the hint string to apply.
      *
-     * @return the hint, which may be null
+     * @return the hint string, which should be the name of an existing index
      * @since 4.1
-     * @mongodb.server.release 4.2
      */
-    public BsonValue getHint() {
-        return hint;
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public UpdateRequest hintString(final String hint) {
+        this.hintString = hint;
+        return this;
     }
 }
 

--- a/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
@@ -180,7 +180,6 @@ public final class UpdateRequest extends WriteRequest {
      * Returns the hint for which index to use. The default is not to set a hint.
      *
      * @return the hint
-     * @since 4.1
      */
     public Bson getHint() {
         return hint;
@@ -191,7 +190,6 @@ public final class UpdateRequest extends WriteRequest {
      *
      * @param hint the hint
      * @return this
-     * @since 4.1
      */
     public UpdateRequest hint(final Bson hint) {
         this.hint = hint;
@@ -202,7 +200,6 @@ public final class UpdateRequest extends WriteRequest {
      * Gets the hint string to apply.
      *
      * @return the hint string, which should be the name of an existing index
-     * @since 4.1
      */
     public String getHintString() {
         return hintString;
@@ -213,7 +210,6 @@ public final class UpdateRequest extends WriteRequest {
      *
      * @param hint the name of the index which should be used for the operation
      * @return this
-     * @since 4.1
      */
     public UpdateRequest hintString(final String hint) {
         this.hintString = hint;

--- a/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
@@ -249,6 +249,15 @@ public final class SplittablePayload {
                     }
                     writer.writeEndArray();
                 }
+                if (update.getHint() != null) {
+                    if (update.getHint().isDocument()) {
+                        writer.writeName("hint");
+                        BsonDocument hint = update.getHint().asDocument();
+                        getCodec(hint).encode(writer, hint, EncoderContext.builder().build());
+                    } else {
+                        writer.writeString("hint", update.getHint().asString().getValue());
+                    }
+                }
                 writer.writeEndDocument();
             } else {
                 DeleteRequest deleteRequest = (DeleteRequest) writeRequestWithIndex.getWriteRequest();

--- a/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
@@ -250,13 +250,11 @@ public final class SplittablePayload {
                     writer.writeEndArray();
                 }
                 if (update.getHint() != null) {
-                    if (update.getHint().isDocument()) {
-                        writer.writeName("hint");
-                        BsonDocument hint = update.getHint().asDocument();
-                        getCodec(hint).encode(writer, hint, EncoderContext.builder().build());
-                    } else {
-                        writer.writeString("hint", update.getHint().asString().getValue());
-                    }
+                    writer.writeName("hint");
+                    BsonDocument hint = update.getHint().toBsonDocument(BsonDocument.class, null);
+                    getCodec(hint).encode(writer, hint, EncoderContext.builder().build());
+                } else if (update.getHintString() != null) {
+                    writer.writeString("hint", update.getHintString());
                 }
                 writer.writeEndDocument();
             } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -887,7 +887,7 @@ final class CommandOperationHelper {
         }
     }
 
-    private static final List<Integer> RETRYABLE_ERROR_CODES = asList(6, 7, 89, 91, 189, 9001, 13436, 13435, 11602, 11600, 10107);
+    private static final List<Integer> RETRYABLE_ERROR_CODES = asList(6, 7, 89, 91, 189, 262, 9001, 13436, 13435, 11602, 11600, 10107);
     static boolean isRetryableException(final Throwable t) {
         if (!(t instanceof MongoException)) {
             return false;

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.operation;
 
+import com.mongodb.MongoClientException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
@@ -25,11 +26,13 @@ import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
+import org.bson.conversions.Bson;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +45,7 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
 import static com.mongodb.internal.operation.OperationHelper.validateCollation;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionFourDotTwo;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -61,6 +65,8 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
     private Collation collation;
+    private Bson hint;
+    private String hintString;
 
     /**
      * Construct a new instance.
@@ -279,6 +285,52 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     /**
+     * Returns the hint for which index to use. The default is not to set a hint.
+     *
+     * @return the hint
+     * @since 4.1
+     */
+    @Nullable
+    public Bson getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     * @since 4.1
+     */
+    public FindAndReplaceOperation<T> hint(@Nullable final Bson hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    /**
+     * Gets the hint string to apply.
+     *
+     * @return the hint string, which should be the name of an existing index
+     * @since 4.1
+     */
+    @Nullable
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 4.1
+     */
+    public FindAndReplaceOperation<T> hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
+    /**
      * Sets the collation options
      *
      * <p>A null value represents the server default.</p>
@@ -325,6 +377,16 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
         addWriteConcernToCommand(connectionDescription, commandDocument, sessionContext);
         if (collation != null) {
             commandDocument.put("collation", collation.asDocument());
+        }
+        if (hint != null || hintString != null) {
+            if (serverIsLessThanVersionFourDotTwo(connectionDescription)) {
+                throw new MongoClientException("Specifying a value for the hint option requires a minimum MongoDB version of 4.2");
+            }
+            if (hint != null) {
+                commandDocument.put("hint", hint.toBsonDocument(BsonDocument.class, null));
+            } else {
+                commandDocument.put("hint", new BsonString(hintString));
+            }
         }
         addTxnNumberToCommand(serverDescription, connectionDescription, commandDocument, sessionContext);
         return commandDocument;

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -272,7 +272,9 @@ final class Operations<TDocument> {
                 .upsert(options.isUpsert())
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation());
+                .collation(options.getCollation())
+                .hint(options.getHint())
+                .hintString(options.getHintString());
     }
 
     FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
@@ -286,12 +288,15 @@ final class Operations<TDocument> {
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
-                .arrayFilters(toBsonDocumentList(options.getArrayFilters()));
+                .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
+                .hint(options.getHint())
+                .hintString(options.getHintString());
     }
 
     FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final List<? extends Bson> update,
                                                        final FindOneAndUpdateOptions options) {
-        return new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(), toBsonDocumentList(update))
+        return new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
+                toBsonDocumentList(update))
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
@@ -300,7 +305,9 @@ final class Operations<TDocument> {
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
-                .arrayFilters(toBsonDocumentList(options.getArrayFilters()));
+                .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
+                .hint(options.getHint())
+                .hintString(options.getHintString());
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -390,7 +390,8 @@ final class Operations<TDocument> {
                         WriteRequest.Type.REPLACE)
                         .upsert(replaceOneModel.getReplaceOptions().isUpsert())
                         .collation(replaceOneModel.getReplaceOptions().getCollation())
-                        .hint(replaceOneModel.getReplaceOptions().getHint());
+                        .hint(replaceOneModel.getReplaceOptions().getHint())
+                        .hintString(replaceOneModel.getReplaceOptions().getHintString());
             } else if (writeModel instanceof UpdateOneModel) {
                 UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
                 BsonValue update = updateOneModel.getUpdate() != null ? toBsonDocument(updateOneModel.getUpdate())
@@ -400,7 +401,8 @@ final class Operations<TDocument> {
                         .upsert(updateOneModel.getOptions().isUpsert())
                         .collation(updateOneModel.getOptions().getCollation())
                         .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()))
-                        .hint(updateOneModel.getOptions().getHint());
+                        .hint(updateOneModel.getOptions().getHint())
+                        .hintString(updateOneModel.getOptions().getHintString());
             } else if (writeModel instanceof UpdateManyModel) {
                 UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
                 BsonValue update = updateManyModel.getUpdate() != null ? toBsonDocument(updateManyModel.getUpdate())
@@ -410,7 +412,8 @@ final class Operations<TDocument> {
                         .upsert(updateManyModel.getOptions().isUpsert())
                         .collation(updateManyModel.getOptions().getCollation())
                         .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()))
-                        .hint(updateManyModel.getOptions().getHint());
+                        .hint(updateManyModel.getOptions().getHint())
+                        .hintString(updateManyModel.getOptions().getHintString());
             } else if (writeModel instanceof DeleteOneModel) {
                 DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -389,7 +389,8 @@ final class Operations<TDocument> {
                         .getReplacement()),
                         WriteRequest.Type.REPLACE)
                         .upsert(replaceOneModel.getReplaceOptions().isUpsert())
-                        .collation(replaceOneModel.getReplaceOptions().getCollation());
+                        .collation(replaceOneModel.getReplaceOptions().getCollation())
+                        .hint(replaceOneModel.getReplaceOptions().getHint());
             } else if (writeModel instanceof UpdateOneModel) {
                 UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
                 BsonValue update = updateOneModel.getUpdate() != null ? toBsonDocument(updateOneModel.getUpdate())
@@ -398,7 +399,8 @@ final class Operations<TDocument> {
                         .multi(false)
                         .upsert(updateOneModel.getOptions().isUpsert())
                         .collation(updateOneModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
+                        .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()))
+                        .hint(updateOneModel.getOptions().getHint());
             } else if (writeModel instanceof UpdateManyModel) {
                 UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
                 BsonValue update = updateManyModel.getUpdate() != null ? toBsonDocument(updateManyModel.getUpdate())
@@ -407,7 +409,8 @@ final class Operations<TDocument> {
                         .multi(true)
                         .upsert(updateManyModel.getOptions().isUpsert())
                         .collation(updateManyModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
+                        .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()))
+                        .hint(updateManyModel.getOptions().getHint());
             } else if (writeModel instanceof DeleteOneModel) {
                 DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -30,6 +30,7 @@ public final class ServerVersionHelper {
     public static final int THREE_DOT_SIX_WIRE_VERSION = 6;
     public static final int FOUR_DOT_ZERO_WIRE_VERSION = 7;
     public static final int FOUR_DOT_TWO_WIRE_VERSION = 8;
+    public static final int FOUR_DOT_FOUR_WIRE_VERSION = 9;
 
     public static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= THREE_DOT_ZERO_WIRE_VERSION;
@@ -55,6 +56,10 @@ public final class ServerVersionHelper {
         return description.getMaxWireVersion() >= FOUR_DOT_TWO_WIRE_VERSION;
     }
 
+    public static boolean serverIsAtLeastVersionFourDotFour(final ConnectionDescription description) {
+        return description.getMaxWireVersion() >= FOUR_DOT_FOUR_WIRE_VERSION;
+    }
+
     public static boolean serverIsLessThanVersionThreeDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() < THREE_DOT_ZERO_WIRE_VERSION;
     }
@@ -77,6 +82,10 @@ public final class ServerVersionHelper {
 
     public static boolean serverIsLessThanVersionFourDotTwo(final ConnectionDescription description) {
         return description.getMaxWireVersion() < FOUR_DOT_TWO_WIRE_VERSION;
+    }
+
+    public static boolean serverIsLessThanVersionFourDotFour(final ConnectionDescription description) {
+        return description.getMaxWireVersion() < FOUR_DOT_FOUR_WIRE_VERSION;
     }
 
     private ServerVersionHelper() {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
@@ -24,7 +24,6 @@ import org.bson.BsonBinary
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonSerializationException
-import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
@@ -88,6 +87,7 @@ class UpdateOperationForReplacementSpecification extends OperationFunctionalSpec
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
                 .hint(hint)
+                .hintString(hintString)
         def operation = new UpdateOperation(getNamespace(), true, ACKNOWLEDGED, false, asList(replacement))
 
         when:
@@ -102,9 +102,10 @@ class UpdateOperationForReplacementSpecification extends OperationFunctionalSpec
         getCollectionHelper().find().get(0).keySet().iterator().next() == '_id'
 
         where:
-        [async, hint] << [
+        [async, hint, hintString] << [
                 [true, false],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_']
         ].combinations()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
@@ -24,10 +24,13 @@ import org.bson.BsonBinary
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonSerializationException
+import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
+import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.getBinding
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.internal.bulk.WriteRequest.Type.REPLACE
 import static java.util.Arrays.asList
@@ -74,6 +77,35 @@ class UpdateOperationForReplacementSpecification extends OperationFunctionalSpec
 
         where:
         async << [true, false]
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    def 'should support hint'() {
+        given:
+        def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
+        new InsertOperation(getNamespace(), true, ACKNOWLEDGED, false, asList(insert)).execute(getBinding())
+
+        def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
+                new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
+                .hint(hint)
+        def operation = new UpdateOperation(getNamespace(), true, ACKNOWLEDGED, false, asList(replacement))
+
+        when:
+        def result = execute(operation, async)
+
+        then:
+        result.wasAcknowledged()
+        result.count == 1
+        result.upsertedId == null
+        result.isUpdateOfExisting()
+        asList(replacement.getUpdateValue()) == getCollectionHelper().find(new BsonDocumentCodec())
+        getCollectionHelper().find().get(0).keySet().iterator().next() == '_id'
+
+        where:
+        [async, hint] << [
+                [true, false],
+                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+        ].combinations()
     }
 
     def 'should upsert a single document'() {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationSpecification.groovy
@@ -26,7 +26,6 @@ import org.bson.BsonBinary
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonObjectId
-import org.bson.BsonString
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import org.bson.types.ObjectId
@@ -308,7 +307,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'))
         def requests = [new UpdateRequest(BsonDocument.parse('{str: "foo"}}'), BsonDocument.parse('{$set: {str: "bar"}}'), UPDATE)
-                                .hint(hint)]
+                                .hint(hint).hintString(hintString)]
         def operation = new UpdateOperation(getNamespace(), false, ACKNOWLEDGED, false, requests)
 
         when:
@@ -318,9 +317,10 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         result.getCount() == 1
 
         where:
-        [async, hint] << [
+        [async, hint, hintString] << [
                 [true, false],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_']
         ].combinations()
     }
 

--- a/driver-core/src/test/resources/auth/connection-string.json
+++ b/driver-core/src/test/resources/auth/connection-string.json
@@ -108,6 +108,16 @@
       }
     },
     {
+      "description": "must raise an error when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": false
+    },
+    {
+      "description": "must raise an error when the authSource is empty without credentials",
+      "uri": "mongodb://localhost/admin?authSource=",
+      "valid": false
+    },
+    {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
       "valid": false

--- a/driver-core/src/test/resources/crud/v2/bulkWrite-arrayFilters.json
+++ b/driver-core/src/test/resources/crud/v2/bulkWrite-arrayFilters.json
@@ -32,7 +32,7 @@
   "database_name": "crud-tests",
   "tests": [
     {
-      "description": "BulkWrite with arrayFilters",
+      "description": "BulkWrite updateOne with arrayFilters",
       "operations": [
         {
           "name": "bulkWrite",
@@ -53,7 +53,86 @@
                     }
                   ]
                 }
-              },
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {},
+                  "u": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 3
+                    }
+                  ]
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "y": [
+                {
+                  "b": 2
+                },
+                {
+                  "b": 1
+                }
+              ]
+            },
+            {
+              "_id": 2,
+              "y": [
+                {
+                  "b": 0
+                },
+                {
+                  "b": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany with arrayFilters",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
               {
                 "name": "updateMany",
                 "arguments": {
@@ -79,8 +158,8 @@
             "deletedCount": 0,
             "insertedCount": 0,
             "insertedIds": {},
-            "matchedCount": 3,
-            "modifiedCount": 3,
+            "matchedCount": 2,
+            "modifiedCount": 2,
             "upsertedCount": 0,
             "upsertedIds": {}
           }
@@ -92,19 +171,6 @@
             "command": {
               "update": "test",
               "updates": [
-                {
-                  "q": {},
-                  "u": {
-                    "$set": {
-                      "y.$[i].b": 2
-                    }
-                  },
-                  "arrayFilters": [
-                    {
-                      "i.b": 3
-                    }
-                  ]
-                },
                 {
                   "q": {},
                   "u": {
@@ -134,7 +200,7 @@
               "_id": 1,
               "y": [
                 {
-                  "b": 2
+                  "b": 3
                 },
                 {
                   "b": 2

--- a/driver-core/src/test/resources/crud/v2/bulkWrite-update-hint.json
+++ b/driver-core/src/test/resources/crud/v2/bulkWrite-update-hint.json
@@ -1,0 +1,250 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "test_bulkwrite_update_hint",
+  "tests": [
+    {
+      "description": "BulkWrite with update hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  },
+                  "replacement": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 8,
+            "modifiedCount": 8,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_bulkwrite_update_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "u": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 4
+                  },
+                  "u": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 15
+            },
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 333
+            },
+            {
+              "_id": 4,
+              "x": 444
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/bulkWrite-update-hint.json
+++ b/driver-core/src/test/resources/crud/v2/bulkWrite-update-hint.json
@@ -25,7 +25,7 @@
   "collection_name": "test_bulkwrite_update_hint",
   "tests": [
     {
-      "description": "BulkWrite with update hints",
+      "description": "BulkWrite updateOne with update hints",
       "operations": [
         {
           "name": "bulkWrite",
@@ -60,7 +60,89 @@
                     "_id": 1
                   }
                 }
-              },
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_bulkwrite_update_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 13
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany with update hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
               {
                 "name": "updateMany",
                 "arguments": {
@@ -94,7 +176,95 @@
                     "_id": 1
                   }
                 }
-              },
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 4,
+            "modifiedCount": 4,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_bulkwrite_update_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 13
+            },
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite replaceOne with update hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
               {
                 "name": "replaceOne",
                 "arguments": {
@@ -130,8 +300,8 @@
             "deletedCount": 0,
             "insertedCount": 0,
             "insertedIds": {},
-            "matchedCount": 8,
-            "modifiedCount": 8,
+            "matchedCount": 2,
+            "modifiedCount": 2,
             "upsertedCount": 0,
             "upsertedIds": {}
           }
@@ -143,60 +313,6 @@
             "command": {
               "update": "test_bulkwrite_update_hint",
               "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": "_id_"
-                },
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": {
-                    "_id": 1
-                  }
-                },
-                {
-                  "q": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "multi": true,
-                  "hint": "_id_"
-                },
-                {
-                  "q": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "multi": true,
-                  "hint": {
-                    "_id": 1
-                  }
-                },
                 {
                   "q": {
                     "_id": 3
@@ -228,11 +344,11 @@
           "data": [
             {
               "_id": 1,
-              "x": 15
+              "x": 11
             },
             {
               "_id": 2,
-              "x": 24
+              "x": 22
             },
             {
               "_id": 3,

--- a/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint-clientError.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint-clientError.json
@@ -1,0 +1,90 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint-serverError.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint-serverError.json
@@ -1,0 +1,123 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.2.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndReplace-hint.json
@@ -1,0 +1,128 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint-clientError.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint-clientError.json
@@ -1,0 +1,94 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint-serverError.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint-serverError.json
@@ -1,0 +1,131 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.2.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint.json
+++ b/driver-core/src/test/resources/crud/v2/findOneAndUpdate-hint.json
@@ -1,0 +1,136 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/replaceOne-hint.json
+++ b/driver-core/src/test/resources/crud/v2/replaceOne-hint.json
@@ -1,0 +1,146 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_replaceone_hint",
+  "tests": [
+    {
+      "description": "ReplaceOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/updateMany-hint.json
+++ b/driver-core/src/test/resources/crud/v2/updateMany-hint.json
@@ -1,0 +1,168 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_updatemany_hint",
+  "tests": [
+    {
+      "description": "UpdateMany with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/v2/updateOne-hint.json
+++ b/driver-core/src/test/resources/crud/v2/updateOne-hint.json
@@ -1,0 +1,154 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_updateone_hint",
+  "tests": [
+    {
+      "description": "UpdateOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "update"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -117,7 +120,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/deleteOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/deleteOne-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "delete"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -73,7 +76,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/findOneAndDelete-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndDelete-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -79,7 +82,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/findOneAndReplace-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndReplace-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -83,7 +86,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -84,7 +87,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/insertMany-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/insertMany-serverErrors.json
@@ -31,7 +31,10 @@
           "failCommands": [
             "insert"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -90,7 +93,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
@@ -81,6 +81,9 @@
             "insert"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -127,6 +130,9 @@
             "insert"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -173,6 +179,9 @@
             "insert"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -219,6 +228,9 @@
             "insert"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -265,6 +277,9 @@
             "insert"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -311,6 +326,9 @@
             "insert"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -357,6 +375,9 @@
             "insert"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -403,6 +424,9 @@
             "insert"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -449,6 +473,9 @@
             "insert"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -495,6 +522,9 @@
             "insert"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -541,6 +571,58 @@
             "insert"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
+          "closeConnection": false
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 3,
+            "x": 33
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "insertedId": 3
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne succeeds after ExceededTimeLimit",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 262,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -633,7 +715,10 @@
           ],
           "writeConcernError": {
             "code": 11600,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -681,7 +766,10 @@
           ],
           "writeConcernError": {
             "code": 11602,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -729,7 +817,10 @@
           ],
           "writeConcernError": {
             "code": 189,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -777,7 +868,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/replaceOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/replaceOne-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "update"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -83,7 +86,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/resources/retryable-writes/updateOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/updateOne-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "update"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -84,7 +87,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -309,6 +309,8 @@ class AggregatesSpecification extends Specification {
     def 'should render $out'() {
         expect:
         toBson(out('authors')) == parse('{ $out : "authors" }')
+        toBson(out(Document.parse('{ s3: "s3://bucket/path/to/file…?format=json&maxFileSize=100MiB"}'))) ==
+                parse('{ $out : { s3: "s3://bucket/path/to/file…?format=json&maxFileSize=100MiB"} }')
     }
 
     def 'should render merge'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndReplaceOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndReplaceOptionsSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.client.model
 
 import org.bson.BsonDocument
+import org.bson.BsonInt32
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -104,5 +105,21 @@ class FindOneAndReplaceOptionsSpecification extends Specification {
 
         where:
         returnDocument << [ReturnDocument.BEFORE, ReturnDocument.AFTER]
+    }
+
+    def 'should set hint'() {
+        expect:
+        new FindOneAndReplaceOptions().hint(hint).getHint() == hint
+
+        where:
+        hint << [null, new BsonDocument('_id', new BsonInt32(1))]
+    }
+
+    def 'should set hint string'() {
+        expect:
+        new FindOneAndReplaceOptions().hintString(hint).getHintString() == hint
+
+        where:
+        hint << [null, '_id_']
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
@@ -115,4 +115,20 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
         where:
         arrayFilters << [null, [], [new BsonDocument('a.b', new BsonInt32(1))]]
     }
+
+    def 'should set hint'() {
+        expect:
+        new FindOneAndUpdateOptions().hint(hint).getHint() == hint
+
+        where:
+        hint << [null, new BsonDocument('_id', new BsonInt32(1))]
+    }
+
+    def 'should set hint string'() {
+        expect:
+        new FindOneAndUpdateOptions().hintString(hint).getHintString() == hint
+
+        where:
+        hint << [null, '_id_']
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
@@ -18,7 +18,6 @@ package com.mongodb.client.model
 
 import org.bson.BsonDocument
 import org.bson.BsonInt32
-import org.bson.BsonString
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -117,6 +116,7 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
         arrayFilters << [null, [], [new BsonDocument('a.b', new BsonInt32(1))]]
     }
 
+
     def 'should set hint'() {
         expect:
         new FindOneAndUpdateOptions().hint(hint).getHint() == hint
@@ -127,10 +127,9 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
 
     def 'should set hint string'() {
         expect:
-        new FindOneAndUpdateOptions().hintString(hint).getHintString() == hint
+        new UpdateOptions().hintString(hint).getHintString() == hint
 
         where:
         hint << [null, '_id_']
-        new UpdateOptions().hint(hint).getHint() == hint
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
@@ -116,7 +116,6 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
         arrayFilters << [null, [], [new BsonDocument('a.b', new BsonInt32(1))]]
     }
 
-
     def 'should set hint'() {
         expect:
         new FindOneAndUpdateOptions().hint(hint).getHint() == hint

--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
@@ -18,6 +18,7 @@ package com.mongodb.client.model
 
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonString
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -130,5 +131,6 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
 
         where:
         hint << [null, '_id_']
+        new UpdateOptions().hint(hint).getHint() == hint
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/UpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/UpdateOptionsSpecification.groovy
@@ -18,7 +18,6 @@ package com.mongodb.client.model
 
 import org.bson.BsonDocument
 import org.bson.BsonInt32
-import org.bson.BsonString
 import spock.lang.Specification
 
 class UpdateOptionsSpecification extends Specification {
@@ -69,6 +68,14 @@ class UpdateOptionsSpecification extends Specification {
         new UpdateOptions().hint(hint).getHint() == hint
 
         where:
-        hint << [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+        hint << [null, new BsonDocument('_id', new BsonInt32(1))]
+    }
+
+    def 'should set hint string'() {
+        expect:
+        new UpdateOptions().hintString(hint).getHintString() == hint
+
+        where:
+        hint << [null, '_id_']
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/UpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/UpdateOptionsSpecification.groovy
@@ -18,6 +18,7 @@ package com.mongodb.client.model
 
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonString
 import spock.lang.Specification
 
 class UpdateOptionsSpecification extends Specification {
@@ -61,5 +62,13 @@ class UpdateOptionsSpecification extends Specification {
 
         where:
         arrayFilters << [null, [], [new BsonDocument('a.b', new BsonInt32(1))]]
+    }
+
+    def 'should set hint'() {
+        expect:
+        new UpdateOptions().hint(hint).getHint() == hint
+
+        where:
+        hint << [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -52,7 +52,9 @@ class OperationUnitSpecification extends Specification {
             [3, 6]: 6,
             [4, 0]: 7,
             [4, 1]: 8,
-            [4, 2]: 8
+            [4, 2]: 8,
+            [4, 3]: 9,
+            [4, 4]: 9
     ]
 
     static int getMaxWireVersionForServerVersion(List<Integer> serverVersion) {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractCrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractCrudTest.java
@@ -22,7 +22,6 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.event.CommandEvent;
 import com.mongodb.event.CommandListener;
-import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.internal.connection.TestCommandListener;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -171,12 +170,7 @@ public abstract class AbstractCrudTest {
             List<CommandEvent> expectedEvents = getExpectedEvents(definition.getArray("expectations"), databaseName, null);
             List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
-            // There are tests where BulkWriteBatch creates two separate commands for updates and replaceOne
-            // when performing a bulk write. Merge the "updates" field in the first command of the events list
-            // with the same field in the second event.
-            if (events.size() == 2) {
-                mergeCommandUpdates(events.get(0), events.get(1));
-            }
+
             assertEventsEquality(expectedEvents, events.subList(0, expectedEvents.size()));
         }
         if (expectedOutcome != null && expectedOutcome.containsKey("collection")) {
@@ -197,15 +191,6 @@ public abstract class AbstractCrudTest {
         if (expectedResult.isDocument() && !expectedResult.asDocument().containsKey(key)) {
             actualResult.asDocument().remove(key);
         }
-    }
-
-    private void mergeCommandUpdates(final CommandEvent updateEvent, final CommandEvent replaceEvent) {
-        if (!updateEvent.getCommandName().equals("update") || !replaceEvent.getCommandName().equals("update")) {
-            return;
-        }
-        CommandStartedEvent update = (CommandStartedEvent) updateEvent;
-        CommandStartedEvent replace = (CommandStartedEvent) replaceEvent;
-        update.getCommand().getArray("updates").addAll(replace.getCommand().getArray("updates"));
     }
 
     @Parameterized.Parameters(name = "{1}")

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -604,6 +604,13 @@ public class JsonPoweredCrudTestHelper {
         if (arguments.containsKey("collation")) {
             options.collation(getCollation(arguments.getDocument("collation")));
         }
+        if (arguments.containsKey("hint")) {
+            if (arguments.isDocument("hint")) {
+                options.hint(arguments.getDocument("hint"));
+            } else {
+                options.hintString(arguments.getString("hint").getValue());
+            }
+        }
 
         BsonDocument result;
         if (clientSession == null) {
@@ -639,7 +646,13 @@ public class JsonPoweredCrudTestHelper {
         if (arguments.containsKey("arrayFilters")) {
             options.arrayFilters((getListOfDocuments(arguments.getArray("arrayFilters"))));
         }
-
+        if (arguments.containsKey("hint")) {
+            if (arguments.isDocument("hint")) {
+                options.hint(arguments.getDocument("hint"));
+            } else {
+                options.hintString(arguments.getString("hint").getValue());
+            }
+        }
         BsonDocument result;
         if (clientSession == null) {
             if (arguments.isDocument("update")) {

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -750,7 +750,7 @@ public class JsonPoweredCrudTestHelper {
             if (arguments.isDocument("hint")) {
                 options.hint(arguments.getDocument("hint"));
             } else {
-                options.hint(arguments.getString("hint"));
+                options.hintString(arguments.getString("hint").getValue());
             }
         }
 
@@ -785,7 +785,7 @@ public class JsonPoweredCrudTestHelper {
             if (arguments.isDocument("hint")) {
                 options.hint(arguments.getDocument("hint"));
             } else {
-                options.hint(arguments.getString("hint"));
+                options.hintString(arguments.getString("hint").getValue());
             }
         }
 
@@ -831,7 +831,7 @@ public class JsonPoweredCrudTestHelper {
             if (arguments.isDocument("hint")) {
                 options.hint(arguments.getDocument("hint"));
             } else {
-                options.hint(arguments.getString("hint"));
+                options.hintString(arguments.getString("hint").getValue());
             }
         }
 
@@ -1080,7 +1080,7 @@ public class JsonPoweredCrudTestHelper {
             if (requestArguments.isDocument("hint")) {
                 options.hint(requestArguments.getDocument("hint"));
             } else {
-                options.hint(requestArguments.getString("hint"));
+                options.hintString(requestArguments.getString("hint").getValue());
             }
         }
         return options;
@@ -1106,7 +1106,7 @@ public class JsonPoweredCrudTestHelper {
             if (requestArguments.isDocument("hint")) {
                 options.hint(requestArguments.getDocument("hint"));
             } else {
-                options.hint(requestArguments.getString("hint"));
+                options.hintString(requestArguments.getString("hint").getValue());
             }
         }
         return options;

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -746,6 +746,13 @@ public class JsonPoweredCrudTestHelper {
         if (arguments.containsKey("bypassDocumentValidation")) {
             options.bypassDocumentValidation(arguments.getBoolean("bypassDocumentValidation").getValue());
         }
+        if (arguments.containsKey("hint")) {
+            if (arguments.isDocument("hint")) {
+                options.hint(arguments.getDocument("hint"));
+            } else {
+                options.hint(arguments.getString("hint"));
+            }
+        }
 
         UpdateResult updateResult;
         if (clientSession == null) {
@@ -773,6 +780,13 @@ public class JsonPoweredCrudTestHelper {
         }
         if (arguments.containsKey("bypassDocumentValidation")) {
             options.bypassDocumentValidation(arguments.getBoolean("bypassDocumentValidation").getValue());
+        }
+        if (arguments.containsKey("hint")) {
+            if (arguments.isDocument("hint")) {
+                options.hint(arguments.getDocument("hint"));
+            } else {
+                options.hint(arguments.getString("hint"));
+            }
         }
 
         UpdateResult updateResult;
@@ -812,6 +826,13 @@ public class JsonPoweredCrudTestHelper {
         }
         if (arguments.containsKey("bypassDocumentValidation")) {
             options.bypassDocumentValidation(arguments.getBoolean("bypassDocumentValidation").getValue());
+        }
+        if (arguments.containsKey("hint")) {
+            if (arguments.isDocument("hint")) {
+                options.hint(arguments.getDocument("hint"));
+            } else {
+                options.hint(arguments.getString("hint"));
+            }
         }
 
         UpdateResult updateResult;
@@ -1055,6 +1076,13 @@ public class JsonPoweredCrudTestHelper {
         if (requestArguments.containsKey("collation")) {
             options.collation(getCollation(requestArguments.getDocument("collation")));
         }
+        if (requestArguments.containsKey("hint")) {
+            if (requestArguments.isDocument("hint")) {
+                options.hint(requestArguments.getDocument("hint"));
+            } else {
+                options.hint(requestArguments.getString("hint"));
+            }
+        }
         return options;
     }
 
@@ -1073,6 +1101,13 @@ public class JsonPoweredCrudTestHelper {
         }
         if (requestArguments.containsKey("collation")) {
             options.collation(getCollation(requestArguments.getDocument("collation")));
+        }
+        if (requestArguments.containsKey("hint")) {
+            if (requestArguments.isDocument("hint")) {
+                options.hint(requestArguments.getDocument("hint"));
+            } else {
+                options.hint(requestArguments.getString("hint"));
+            }
         }
         return options;
     }

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -78,6 +78,8 @@ import com.mongodb.internal.operation.MixedBulkWriteOperation
 import com.mongodb.internal.operation.RenameCollectionOperation
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonString
+import org.bson.BsonValue
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.BsonValueCodecProvider
@@ -487,17 +489,19 @@ class MongoCollectionSpecification extends Specification {
             new MixedBulkWriteOperation(namespace, [
                     new InsertRequest(BsonDocument.parse('{_id: 1}')),
                     new UpdateRequest(BsonDocument.parse('{a: 2}'), BsonDocument.parse('{a: 200}'), REPLACE)
-                            .multi(false).upsert(true).collation(collation),
+                            .multi(false).upsert(true).collation(collation).hint(hint),
                     new UpdateRequest(BsonDocument.parse('{a: 3}'), BsonDocument.parse('{$set: {a: 1}}'), UPDATE)
-                            .multi(false).upsert(true).collation(collation).arrayFilters(arrayFilters),
+                            .multi(false).upsert(true).collation(collation).arrayFilters(arrayFilters)
+                            .hint(hint),
                     new UpdateRequest(BsonDocument.parse('{a: 4}'), BsonDocument.parse('{$set: {a: 1}}'), UPDATE).multi(true)
-                            .upsert(true).collation(collation).arrayFilters(arrayFilters),
+                            .upsert(true).collation(collation).arrayFilters(arrayFilters).hint(hint),
                     new DeleteRequest(BsonDocument.parse('{a: 5}')).multi(false),
                     new DeleteRequest(BsonDocument.parse('{a: 6}')).multi(true).collation(collation)
             ], ordered, wc, retryWrites).bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateOptions = new UpdateOptions().upsert(true).collation(collation).arrayFilters(arrayFilters)
-        def replaceOptions = new ReplaceOptions().upsert(true).collation(collation)
+                .hint(hint)
+        def replaceOptions = new ReplaceOptions().upsert(true).collation(collation).hint(hint)
         def deleteOptions = new DeleteOptions().collation(collation)
         def bulkOperations = [new InsertOneModel(BsonDocument.parse('{_id: 1}')),
                               new ReplaceOneModel(BsonDocument.parse('{a: 2}'), BsonDocument.parse('{a: 200}'), replaceOptions),
@@ -532,9 +536,10 @@ class MongoCollectionSpecification extends Specification {
         expect operation, isTheSameAs(expectedOperation(false, writeConcern, false, arrayFilters))
 
         where:
-        [writeConcern, arrayFilters, session, retryWrites, retryReads] << [
+        [writeConcern, arrayFilters, hint, session, retryWrites, retryReads] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
+                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))],
                 [null, Stub(ClientSession)],
                 [true, false]
         ].combinations()
@@ -797,14 +802,15 @@ class MongoCollectionSpecification extends Specification {
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), REPLACE)
-                             .collation(collation).upsert(upsert)], true, wc, retryWrites)
+                             .collation(collation).upsert(upsert).hint(hint)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def replaceOneMethod = collection.&replaceOne
 
         when:
         def result = execute(replaceOneMethod, session, new Document('a', 1), new Document('a', 10),
-                new ReplaceOptions().upsert(true).bypassDocumentValidation(bypassDocumentValidation).collation(collation))
+                new ReplaceOptions().upsert(true).bypassDocumentValidation(bypassDocumentValidation).collation(collation)
+                        .hint(hint))
         executor.getClientSession() == session
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
@@ -813,13 +819,14 @@ class MongoCollectionSpecification extends Specification {
         result == expectedResult
 
         where:
-        [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites] << [
+        [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites, hint] << [
                 [null, true, false],
                 [1],
                 [null, new BsonInt32(42)],
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, Stub(ClientSession)],
-                [true, false]
+                [true, false],
+                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
         ].combinations()
     }
 
@@ -861,10 +868,11 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
                 retryWrites, true, readConcern, JAVA_LEGACY, executor)
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation,
-            List<Bson> arrayFilters ->
+                                  List<Bson> arrayFilters, BsonValue hint ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), UPDATE)
-                             .multi(false).upsert(upsert).collation(collation).arrayFilters(arrayFilters)], true, wc, retryWrites)
+                             .multi(false).upsert(upsert).collation(collation).arrayFilters(arrayFilters)
+                             .hint(hint)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateOneMethod = collection.&updateOne
@@ -874,27 +882,28 @@ class MongoCollectionSpecification extends Specification {
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null))
+        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null))
         executor.getClientSession() == session
         result == expectedResult
 
         when:
         result = execute(updateOneMethod, session, new Document('a', 1), new Document('a', 10),
                 new UpdateOptions().upsert(true).bypassDocumentValidation(true).collation(collation)
-                        .arrayFilters(arrayFilters))
+                        .arrayFilters(arrayFilters).hint(hint))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters))
+        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint))
         executor.getClientSession() == session
         result == expectedResult
 
         where:
-        [writeConcern, arrayFilters, session, retryWrites] << [
+        [writeConcern, arrayFilters, session, retryWrites, hint] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
                 [null, Stub(ClientSession)],
-                [true, false]
+                [true, false],
+                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
         ].combinations()
     }
 
@@ -907,10 +916,11 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
                 retryWrites, true, readConcern, JAVA_LEGACY, executor)
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation,
-                                  List<Bson> arrayFilters ->
+                                  List<Bson> arrayFilters, BsonValue hint ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), UPDATE)
-                             .multi(true).upsert(upsert).collation(collation).arrayFilters(arrayFilters)], true, wc, retryWrites)
+                             .multi(true).upsert(upsert).collation(collation).arrayFilters(arrayFilters)
+                             .hint(hint)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateManyMethod = collection.&updateMany
@@ -920,25 +930,26 @@ class MongoCollectionSpecification extends Specification {
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null))
+        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null))
         result == expectedResult
 
         when:
         result = execute(updateManyMethod, session, new Document('a', 1), new Document('a', 10),
                 new UpdateOptions().upsert(true).bypassDocumentValidation(true).collation(collation)
-                        .arrayFilters(arrayFilters))
+                        .arrayFilters(arrayFilters).hint(hint))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters))
+        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint))
         result == expectedResult
 
         where:
-        [writeConcern, arrayFilters, session, retryWrites] << [
+        [writeConcern, arrayFilters, session, retryWrites, hint] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
                 [null, Stub(ClientSession)],
-                [true, false]
+                [true, false],
+                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
         ].combinations()
     }
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -78,8 +78,6 @@ import com.mongodb.internal.operation.MixedBulkWriteOperation
 import com.mongodb.internal.operation.RenameCollectionOperation
 import org.bson.BsonDocument
 import org.bson.BsonInt32
-import org.bson.BsonString
-import org.bson.BsonValue
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.BsonValueCodecProvider
@@ -489,19 +487,19 @@ class MongoCollectionSpecification extends Specification {
             new MixedBulkWriteOperation(namespace, [
                     new InsertRequest(BsonDocument.parse('{_id: 1}')),
                     new UpdateRequest(BsonDocument.parse('{a: 2}'), BsonDocument.parse('{a: 200}'), REPLACE)
-                            .multi(false).upsert(true).collation(collation).hint(hint),
+                            .multi(false).upsert(true).collation(collation).hint(hint).hintString(hintString),
                     new UpdateRequest(BsonDocument.parse('{a: 3}'), BsonDocument.parse('{$set: {a: 1}}'), UPDATE)
                             .multi(false).upsert(true).collation(collation).arrayFilters(arrayFilters)
-                            .hint(hint),
+                            .hint(hint).hintString(hintString),
                     new UpdateRequest(BsonDocument.parse('{a: 4}'), BsonDocument.parse('{$set: {a: 1}}'), UPDATE).multi(true)
-                            .upsert(true).collation(collation).arrayFilters(arrayFilters).hint(hint),
+                            .upsert(true).collation(collation).arrayFilters(arrayFilters).hint(hint).hintString(hintString),
                     new DeleteRequest(BsonDocument.parse('{a: 5}')).multi(false),
                     new DeleteRequest(BsonDocument.parse('{a: 6}')).multi(true).collation(collation)
             ], ordered, wc, retryWrites).bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateOptions = new UpdateOptions().upsert(true).collation(collation).arrayFilters(arrayFilters)
-                .hint(hint)
-        def replaceOptions = new ReplaceOptions().upsert(true).collation(collation).hint(hint)
+                .hint(hint).hintString(hintString)
+        def replaceOptions = new ReplaceOptions().upsert(true).collation(collation).hint(hint).hintString(hintString)
         def deleteOptions = new DeleteOptions().collation(collation)
         def bulkOperations = [new InsertOneModel(BsonDocument.parse('{_id: 1}')),
                               new ReplaceOneModel(BsonDocument.parse('{a: 2}'), BsonDocument.parse('{a: 200}'), replaceOptions),
@@ -536,10 +534,11 @@ class MongoCollectionSpecification extends Specification {
         expect operation, isTheSameAs(expectedOperation(false, writeConcern, false, arrayFilters))
 
         where:
-        [writeConcern, arrayFilters, hint, session, retryWrites, retryReads] << [
+        [writeConcern, arrayFilters, hint, hintString, session, retryWrites, retryReads] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))],
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_'],
                 [null, Stub(ClientSession)],
                 [true, false]
         ].combinations()
@@ -802,7 +801,7 @@ class MongoCollectionSpecification extends Specification {
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), REPLACE)
-                             .collation(collation).upsert(upsert).hint(hint)], true, wc, retryWrites)
+                             .collation(collation).upsert(upsert).hint(hint).hintString(hintString)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def replaceOneMethod = collection.&replaceOne
@@ -810,7 +809,7 @@ class MongoCollectionSpecification extends Specification {
         when:
         def result = execute(replaceOneMethod, session, new Document('a', 1), new Document('a', 10),
                 new ReplaceOptions().upsert(true).bypassDocumentValidation(bypassDocumentValidation).collation(collation)
-                        .hint(hint))
+                        .hint(hint).hintString(hintString))
         executor.getClientSession() == session
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
@@ -819,14 +818,15 @@ class MongoCollectionSpecification extends Specification {
         result == expectedResult
 
         where:
-        [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites, hint] << [
+        [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites, hint, hintString] << [
                 [null, true, false],
                 [1],
                 [null, new BsonInt32(42)],
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, Stub(ClientSession)],
                 [true, false],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_']
         ].combinations()
     }
 
@@ -868,11 +868,11 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
                 retryWrites, true, readConcern, JAVA_LEGACY, executor)
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation,
-                                  List<Bson> arrayFilters, BsonValue hint ->
+                                  List<Bson> arrayFilters, BsonDocument hint, String hintString ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), UPDATE)
                              .multi(false).upsert(upsert).collation(collation).arrayFilters(arrayFilters)
-                             .hint(hint)], true, wc, retryWrites)
+                             .hint(hint).hintString(hintString)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateOneMethod = collection.&updateOne
@@ -882,28 +882,29 @@ class MongoCollectionSpecification extends Specification {
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null))
+        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null, null))
         executor.getClientSession() == session
         result == expectedResult
 
         when:
         result = execute(updateOneMethod, session, new Document('a', 1), new Document('a', 10),
                 new UpdateOptions().upsert(true).bypassDocumentValidation(true).collation(collation)
-                        .arrayFilters(arrayFilters).hint(hint))
+                        .arrayFilters(arrayFilters).hint(hint).hintString(hintString))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint))
+        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint, hintString))
         executor.getClientSession() == session
         result == expectedResult
 
         where:
-        [writeConcern, arrayFilters, session, retryWrites, hint] << [
+        [writeConcern, arrayFilters, session, retryWrites, hint, hintString] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
                 [null, Stub(ClientSession)],
                 [true, false],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_']
         ].combinations()
     }
 
@@ -916,11 +917,11 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
                 retryWrites, true, readConcern, JAVA_LEGACY, executor)
         def expectedOperation = { boolean upsert, WriteConcern wc, Boolean bypassDocumentValidation, Collation collation,
-                                  List<Bson> arrayFilters, BsonValue hint ->
+                                  List<Bson> arrayFilters, BsonDocument hint, String hintString ->
             new MixedBulkWriteOperation(namespace,
                     [new UpdateRequest(new BsonDocument('a', new BsonInt32(1)), new BsonDocument('a', new BsonInt32(10)), UPDATE)
                              .multi(true).upsert(upsert).collation(collation).arrayFilters(arrayFilters)
-                             .hint(hint)], true, wc, retryWrites)
+                             .hint(hint).hintString(hintString)], true, wc, retryWrites)
                     .bypassDocumentValidation(bypassDocumentValidation)
         }
         def updateManyMethod = collection.&updateMany
@@ -930,26 +931,28 @@ class MongoCollectionSpecification extends Specification {
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null))
+        expect operation, isTheSameAs(expectedOperation(false, writeConcern, null, null, null, null, null))
         result == expectedResult
 
         when:
         result = execute(updateManyMethod, session, new Document('a', 1), new Document('a', 10),
                 new UpdateOptions().upsert(true).bypassDocumentValidation(true).collation(collation)
-                        .arrayFilters(arrayFilters).hint(hint))
+                        .arrayFilters(arrayFilters).hint(hint).hintString(hintString))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
-        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint))
+        expect operation, isTheSameAs(expectedOperation(true, writeConcern, true, collation, arrayFilters, hint,
+                hintString))
         result == expectedResult
 
         where:
-        [writeConcern, arrayFilters, session, retryWrites, hint] << [
+        [writeConcern, arrayFilters, session, retryWrites, hint, hintString] << [
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, [], [new BsonDocument('a.b', new BsonInt32(42))]],
                 [null, Stub(ClientSession)],
                 [true, false],
-                [null, new BsonString('_id_'), new BsonDocument('_id', new BsonInt32(1))]
+                [null, new BsonDocument('_id', new BsonInt32(1))],
+                [null, '_id_']
         ].combinations()
     }
 


### PR DESCRIPTION
JAVA-3475

Evergreen patch: https://evergreen.mongodb.com/version/5e3c65fd32f41775497f6a60

I did not see any required updates for reactive streams or Scala. If there are any suggestions for updates in reactive streams or Scala, let me know.