### PR TITLE
Reduce floating point precision required of extended json implementations

### DIFF
--- a/bson/src/test/resources/bson/double.json
+++ b/bson/src/test/resources/bson/double.json
@@ -28,16 +28,16 @@
             "relaxed_extjson": "{\"d\" : -1.0001220703125}"
         },
         {
-            "description": "1.23456789012345677E18",
-            "canonical_bson": "1000000001640081E97DF41022B14300",
-            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"1.23456789012345677E18\"}}",
-            "relaxed_extjson": "{\"d\" : 1.23456789012345677E18}"
+            "description": "1.2345678921232E18",
+            "canonical_bson": "100000000164002a1bf5f41022b14300",
+            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"1.2345678921232E18\"}}",
+            "relaxed_extjson": "{\"d\" : 1.2345678921232E18}"
         },
         {
-            "description": "-1.23456789012345677E18",
-            "canonical_bson": "1000000001640081E97DF41022B1C300",
-            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"-1.23456789012345677E18\"}}",
-            "relaxed_extjson": "{\"d\" : -1.23456789012345677E18}"
+            "description": "-1.2345678921232E18",
+            "canonical_bson": "100000000164002a1bf5f41022b1c300",
+            "canonical_extjson": "{\"d\" : {\"$numberDouble\": \"-1.2345678921232E18\"}}",
+            "relaxed_extjson": "{\"d\" : -1.2345678921232E18}"
         },
         {
             "description": "0.0",


### PR DESCRIPTION
JAVA-3601
I ran the bson tests locally to confirm support for reduced floating point precision.