### PR TITLE
Specify behavior of empty authSource URI option

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -693,6 +693,9 @@ public class ConnectionString {
                     mechanism = AuthenticationMechanism.fromMechanismName(value);
                 }
             } else if (key.equals("authsource")) {
+                if (value.equals("")) {
+                    throw new IllegalArgumentException("authSource can not be an empty string");
+                }
                 authSource = value;
             } else if (key.equals("gssapiservicename")) {
                 gssapiServiceName = value;

--- a/driver-core/src/test/resources/auth/connection-string.json
+++ b/driver-core/src/test/resources/auth/connection-string.json
@@ -108,6 +108,16 @@
       }
     },
     {
+      "description": "must raise an error when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": false
+    },
+    {
+      "description": "must raise an error when the authSource is empty without credentials",
+      "uri": "mongodb://localhost/admin?authSource=",
+      "valid": false
+    },
+    {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
       "valid": false


### PR DESCRIPTION
JAVA-3617
Evergreen patch: https://evergreen.mongodb.com/version/5e41eb2e850e6158fa94341e