### PR TITLE
Bump wire protocol version for 4.4

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ServerDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerDescription.java
@@ -61,7 +61,7 @@ public class ServerDescription {
      * The maximum supported driver wire version
      * @since 3.8
      */
-    public static final int MAX_DRIVER_WIRE_VERSION = 8;
+    public static final int MAX_DRIVER_WIRE_VERSION = 9;
 
     private static final int DEFAULT_MAX_DOCUMENT_SIZE = 0x1000000;  // 16MB
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -30,6 +30,7 @@ public final class ServerVersionHelper {
     public static final int THREE_DOT_SIX_WIRE_VERSION = 6;
     public static final int FOUR_DOT_ZERO_WIRE_VERSION = 7;
     public static final int FOUR_DOT_TWO_WIRE_VERSION = 8;
+    public static final int FOUR_DOT_FOUR_WIRE_VERSION = 9;
 
     public static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= THREE_DOT_ZERO_WIRE_VERSION;
@@ -55,6 +56,10 @@ public final class ServerVersionHelper {
         return description.getMaxWireVersion() >= FOUR_DOT_TWO_WIRE_VERSION;
     }
 
+    public static boolean serverIsAtLeastVersionFourDotFour(final ConnectionDescription description) {
+        return description.getMaxWireVersion() >= FOUR_DOT_FOUR_WIRE_VERSION;
+    }
+
     public static boolean serverIsLessThanVersionThreeDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() < THREE_DOT_ZERO_WIRE_VERSION;
     }
@@ -77,6 +82,10 @@ public final class ServerVersionHelper {
 
     public static boolean serverIsLessThanVersionFourDotTwo(final ConnectionDescription description) {
         return description.getMaxWireVersion() < FOUR_DOT_TWO_WIRE_VERSION;
+    }
+
+    public static boolean serverIsLessThanVersionFourDotFour(final ConnectionDescription description) {
+        return description.getMaxWireVersion() < FOUR_DOT_FOUR_WIRE_VERSION;
     }
 
     private ServerVersionHelper() {

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -52,7 +52,9 @@ class OperationUnitSpecification extends Specification {
             [3, 6]: 6,
             [4, 0]: 7,
             [4, 1]: 8,
-            [4, 2]: 8
+            [4, 2]: 8,
+            [4, 3]: 9,
+            [4, 4]: 9
     ]
 
     static int getMaxWireVersionForServerVersion(List<Integer> serverVersion) {


### PR DESCRIPTION
JAVA-3427
Evergreen patch: https://evergreen.mongodb.com/version/5e41fe882fbabe40d2593108