### PR TITLE
Disable change stream test for latest sever variant

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/async/client/ChangeStreamProseTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/async/client/ChangeStreamProseTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.internal.async.client.Fixture.getDefaultDatabaseName;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -73,6 +74,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testMissingResumeTokenThrowsException() {
+        assumeTrue(serverVersionLessThan(4, 3));
         boolean exceptionFound = false;
         AsyncBatchCursor<ChangeStreamDocument<Document>> cursor =
                 createChangeStreamCursor(collection.watch(singletonList(Aggregates.project(Document.parse("{ _id : 0 }")))));

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -402,6 +402,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
+    @IgnoreIf({ serverVersionAtLeast(4, 3) })
     def 'should throw if the _id field is projected out'() {
         given:
         def helper = getHelper()

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractChangeStreamsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractChangeStreamsTest.java
@@ -29,6 +29,7 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonDocumentCodec;
 import org.junit.After;
@@ -235,6 +236,10 @@ public abstract class AbstractChangeStreamsTest {
                     testDocument.getString("collection2_name").getValue());
 
             for (BsonValue test : testDocument.getArray("tests")) {
+                if (test.asDocument().getString("description").getValue()
+                        .equals("Change Stream should error when _id is projected out")) {
+                    test.asDocument().put("maxServerVersion", new BsonString("4.2"));
+                }
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
                         namespace, namespace2, test.asDocument(), skipTest(testDocument, test.asDocument())});
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
@@ -123,6 +123,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testMissingResumeTokenThrowsException() {
+        assumeTrue(serverVersionLessThan(4, 3));
         boolean exceptionFound = false;
 
         MongoCursor<ChangeStreamDocument<Document>> cursor = collection.watch(asList(Aggregates.project(Document.parse("{ _id : 0 }"))))


### PR DESCRIPTION
JAVA-3624
Evergreen patch: https://evergreen.mongodb.com/version/5e431af3e3c3316aaefd3e87

Change stream tests where _id is projected out are failing on the latest server variant on Evergreen because of the fix for SERVER-45505.
These tests will be re-enabled or removed after SPEC-1505 is resolved.