### PR TITLE
Update FindOneAndUpdateOptions test

### DIFF
--- a/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FindOneAndUpdateOptionsSpecification.groovy
@@ -110,7 +110,7 @@ class FindOneAndUpdateOptionsSpecification extends Specification {
 
     def 'should set array filters'() {
         expect:
-        new UpdateOptions().arrayFilters(arrayFilters).getArrayFilters() == arrayFilters
+        new FindOneAndUpdateOptions().arrayFilters(arrayFilters).getArrayFilters() == arrayFilters
 
         where:
         arrayFilters << [null, [], [new BsonDocument('a.b', new BsonInt32(1))]]


### PR DESCRIPTION
JAVA-3498
Evergreen patch: https://evergreen.mongodb.com/version/5e4321a0306615219ab579cc
One test for FindOneAndUpdateOptions found in the review for JAVA-3475 needed updating.