### PR TITLE
Improve testing around default writeConcern

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -227,10 +227,23 @@ public final class CommandMonitoringTestHelper {
         if (command.containsKey("maxTimeMS")) {
             command.put("maxTimeMS", new BsonInt32(command.getNumber("maxTimeMS").intValue()));
         }
+        // Tests do not expect the "ns" field in a result after running createIndex.
+        if (command.containsKey("createIndexes") && command.containsKey("indexes")) {
+            massageCommandIndexes(command.getArray("indexes"));
+        }
         massageActualCommand(command, expectedCommandStartedEvent.getCommand());
 
         return new CommandStartedEvent(event.getRequestId(), event.getConnectionDescription(), event.getDatabaseName(),
                 event.getCommandName(), command);
+    }
+
+    private static void massageCommandIndexes(final BsonArray indexes) {
+        for (BsonValue indexDocument : indexes) {
+            BsonDocument index = indexDocument.asDocument();
+            if (index.containsKey("ns")) {
+                index.remove("ns");
+            }
+        }
     }
 
     private static void massageActualCommand(final BsonDocument command, final BsonDocument expectedCommand) {

--- a/driver-core/src/test/resources/write-concern/operation/default-write-concern-2.6.json
+++ b/driver-core/src/test/resources/write-concern/operation/default-write-concern-2.6.json
@@ -1,0 +1,544 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "2.6"
+    }
+  ],
+  "tests": [
+    {
+      "description": "DeleteOne omits default write concern",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "DeleteMany omits default write concern",
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite with all models omits default write concern",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "ordered": true,
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {}
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 2
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "x": 2
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 3
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 3
+                    }
+                  }
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 3
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "x": 2
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 3
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "InsertOne and InsertMany omit default write concern",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 4
+                },
+                {
+                  "_id": 5
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne, UpdateMany, and ReplaceOne omit default write concern",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "update": {
+              "$set": {
+                "x": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 3
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            },
+            {
+              "_id": 2,
+              "x": 3
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 2
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "x": 3
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/write-concern/operation/default-write-concern-3.2.json
+++ b/driver-core/src/test/resources/write-concern/operation/default-write-concern-3.2.json
@@ -1,0 +1,125 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "3.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "findAndModify operations omit default write concern",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$set": {
+                  "x": 1
+                }
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "update": {
+                "x": 2
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "remove": true,
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/write-concern/operation/default-write-concern-3.4.json
+++ b/driver-core/src/test/resources/write-concern/operation/default-write-concern-3.4.json
@@ -1,0 +1,216 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_collection_name"
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_collection_name"
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "RunCommand with a write command omits default write concern (runCommand should never inherit write concern)",
+      "operations": [
+        {
+          "object": "database",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "name": "runCommand",
+          "command_name": "delete",
+          "arguments": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateIndex and dropIndex omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "createIndex",
+          "arguments": {
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "dropIndex",
+          "arguments": {
+            "name": "x_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "default_write_concern_coll",
+              "indexes": [
+                {
+                  "name": "x_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "dropIndexes": "default_write_concern_coll",
+              "index": "x_1",
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "MapReduce omits default write concern",
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "mapReduce": "default_write_concern_coll",
+              "map": {
+                "$code": "function inc() { return emit(0, this.x + 1) }"
+              },
+              "reduce": {
+                "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+              },
+              "out": {
+                "inline": 1
+              },
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/write-concern/operation/default-write-concern-4.2.json
+++ b/driver-core/src/test/resources/write-concern/operation/default-write-concern-4.2.json
@@ -1,0 +1,87 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $merge omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_collection_name"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_collection_name"
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/WriteConcernOperationTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/WriteConcernOperationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.AbstractWriteConcernOperationTest;
+import com.mongodb.client.MongoClient;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+
+// See https://github.com/mongodb/specifications/tree/master/source/read-write-concern/tests/operation
+public class WriteConcernOperationTest extends AbstractWriteConcernOperationTest {
+
+    public WriteConcernOperationTest(final String filename, final String description, final String databaseName,
+                                     final String collectionName, final BsonArray data, final BsonDocument definition,
+                                     final boolean skipTest) {
+        super(filename, description, databaseName, collectionName, data, definition, skipTest);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return new SyncMongoClient(MongoClients.create(settings));
+    }
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
@@ -743,22 +743,30 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
 
     @Override
     public String createIndex(final Bson keys) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<String> subscriber = new SingleResultSubscriber<>();
+        wrapped.createIndex(keys).subscribe(subscriber);
+        return requireNonNull(subscriber.get());
     }
 
     @Override
     public String createIndex(final Bson keys, final IndexOptions indexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<String> subscriber = new SingleResultSubscriber<>();
+        wrapped.createIndex(keys, indexOptions).subscribe(subscriber);
+        return requireNonNull(subscriber.get());
     }
 
     @Override
     public String createIndex(final ClientSession clientSession, final Bson keys) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<String> subscriber = new SingleResultSubscriber<>();
+        wrapped.createIndex(unwrap(clientSession), keys).subscribe(subscriber);
+        return requireNonNull(subscriber.get());
     }
 
     @Override
     public String createIndex(final ClientSession clientSession, final Bson keys, final IndexOptions indexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<String> subscriber = new SingleResultSubscriber<>();
+        wrapped.createIndex(unwrap(clientSession), keys, indexOptions).subscribe(subscriber);
+        return requireNonNull(subscriber.get());
     }
 
     @Override
@@ -804,42 +812,58 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
 
     @Override
     public void dropIndex(final String indexName) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(indexName).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(indexName, dropIndexOptions).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final Bson keys) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(keys).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(keys, dropIndexOptions).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final ClientSession clientSession, final String indexName) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(unwrap(clientSession), indexName).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final ClientSession clientSession, final Bson keys) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(unwrap(clientSession), keys).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final ClientSession clientSession, final String indexName, final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(unwrap(clientSession), indexName, dropIndexOptions).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override
     public void dropIndex(final ClientSession clientSession, final Bson keys, final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        SingleResultSubscriber<Void> subscriber = new SingleResultSubscriber<>();
+        wrapped.dropIndex(unwrap(clientSession), keys, dropIndexOptions).subscribe(subscriber);
+        subscriber.get();
     }
 
     @Override

--- a/driver-scala/src/it/scala/org/mongodb/scala/WriteConcernOperationTest.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/WriteConcernOperationTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala
+
+import com.mongodb.client.AbstractWriteConcernOperationTest
+import org.bson.{ BsonArray, BsonDocument }
+import org.mongodb.scala.syncadapter.SyncMongoClient
+
+class WriteConcernOperationTest(
+    val filename: String,
+    val description: String,
+    val databaseName: String,
+    val collectionName: String,
+    val data: BsonArray,
+    val definition: BsonDocument,
+    val skipTest: Boolean
+) extends AbstractWriteConcernOperationTest(
+      filename,
+      description,
+      databaseName,
+      collectionName,
+      data,
+      definition,
+      skipTest
+    ) {
+  override def createMongoClient(settings: com.mongodb.MongoClientSettings) = SyncMongoClient(MongoClient(settings))
+}

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCollection.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCollection.scala
@@ -467,14 +467,16 @@ case class SyncMongoCollection[T](wrapped: MongoCollection[T]) extends JMongoCol
 
   override def drop(clientSession: ClientSession): Unit = wrapped.drop(unwrap(clientSession)).toFuture().get()
 
-  override def createIndex(keys: Bson) = throw new UnsupportedOperationException
+  override def createIndex(keys: Bson): String = wrapped.createIndex(keys).toFuture().get()
 
-  override def createIndex(keys: Bson, indexOptions: IndexOptions) = throw new UnsupportedOperationException
+  override def createIndex(keys: Bson, indexOptions: IndexOptions) =
+    wrapped.createIndex(keys, indexOptions).toFuture().get()
 
-  override def createIndex(clientSession: ClientSession, keys: Bson) = throw new UnsupportedOperationException
+  override def createIndex(clientSession: ClientSession, keys: Bson) =
+    wrapped.createIndex(unwrap(clientSession), keys).toFuture().get()
 
   override def createIndex(clientSession: ClientSession, keys: Bson, indexOptions: IndexOptions) =
-    throw new UnsupportedOperationException
+    wrapped.createIndex(unwrap(clientSession), keys, indexOptions).toFuture().get()
 
   override def createIndexes(indexes: java.util.List[IndexModel]) = throw new UnsupportedOperationException
 
@@ -503,37 +505,28 @@ case class SyncMongoCollection[T](wrapped: MongoCollection[T]) extends JMongoCol
   override def listIndexes[TResult](clientSession: ClientSession, resultClass: Class[TResult]) =
     throw new UnsupportedOperationException
 
-  override def dropIndex(indexName: String): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(indexName: String): Unit = wrapped.dropIndex(indexName).toFuture().get()
 
-  override def dropIndex(indexName: String, dropIndexOptions: DropIndexOptions): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(indexName: String, dropIndexOptions: DropIndexOptions): Unit =
+    wrapped.dropIndex(indexName, dropIndexOptions).toFuture().get()
 
-  override def dropIndex(keys: Bson): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(keys: Bson): Unit =
+    wrapped.dropIndex(keys).toFuture().get()
 
-  override def dropIndex(keys: Bson, dropIndexOptions: DropIndexOptions): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(keys: Bson, dropIndexOptions: DropIndexOptions): Unit =
+    wrapped.dropIndex(keys, dropIndexOptions).toFuture().get()
 
-  override def dropIndex(clientSession: ClientSession, indexName: String): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(clientSession: ClientSession, indexName: String): Unit =
+    wrapped.dropIndex(unwrap(clientSession), indexName).toFuture().get()
 
-  override def dropIndex(clientSession: ClientSession, keys: Bson): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(clientSession: ClientSession, keys: Bson): Unit =
+    wrapped.dropIndex(unwrap(clientSession), keys).toFuture().get()
 
-  override def dropIndex(clientSession: ClientSession, indexName: String, dropIndexOptions: DropIndexOptions): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(clientSession: ClientSession, indexName: String, dropIndexOptions: DropIndexOptions): Unit =
+    wrapped.dropIndex(unwrap(clientSession), indexName, dropIndexOptions).toFuture().get()
 
-  override def dropIndex(clientSession: ClientSession, keys: Bson, dropIndexOptions: DropIndexOptions): Unit = {
-    throw new UnsupportedOperationException
-  }
+  override def dropIndex(clientSession: ClientSession, keys: Bson, dropIndexOptions: DropIndexOptions): Unit =
+    wrapped.dropIndex(unwrap(clientSession), keys, dropIndexOptions).toFuture().get()
 
   override def dropIndexes(): Unit = {
     throw new UnsupportedOperationException

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractWriteConcernOperationTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractWriteConcernOperationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.mongodb.JsonTestServerVersionChecker.skipTest;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+
+// See https://github.com/mongodb/specifications/tree/master/source/read-write-concern/tests/operation
+@RunWith(Parameterized.class)
+public abstract class AbstractWriteConcernOperationTest extends AbstractUnifiedTest {
+    public AbstractWriteConcernOperationTest(final String filename, final String description, final String databaseName,
+                                             final String collectionName, final BsonArray data, final BsonDocument definition,
+                                             final boolean skipTest) {
+        super(filename, description, databaseName, collectionName, data, definition, skipTest);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/write-concern/operation")) {
+            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
+
+            for (BsonValue test : testDocument.getArray("tests")) {
+                data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
+                        testDocument.getString("collection_name", new BsonString("test")).getValue(),
+                        testDocument.getArray("data"), test.asDocument(), skipTest(testDocument, test.asDocument())});
+            }
+        }
+        return data;
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -369,6 +369,27 @@ public class JsonPoweredCrudTestHelper {
         return toResult(iterable);
     }
 
+    BsonDocument getCreateIndexResult(final BsonDocument collectionOptions, final BsonDocument arguments,
+                                      @Nullable final ClientSession clientSession) {
+        String index;
+        if (clientSession == null) {
+            index = getCollection(collectionOptions).createIndex(arguments.getDocument("keys", new BsonDocument()));
+        } else {
+            index = getCollection(collectionOptions).createIndex(clientSession, arguments.getDocument("keys", new BsonDocument()));
+        }
+        return toResult("result", new BsonString(index));
+    }
+
+    BsonDocument getDropIndexResult(final BsonDocument collectionOptions, final BsonDocument arguments,
+                                    @Nullable final ClientSession clientSession) {
+        if (clientSession == null) {
+            getCollection(collectionOptions).dropIndex(arguments.getString("name").getValue());
+        } else {
+            getCollection(collectionOptions).dropIndex(clientSession, arguments.getString("name").getValue());
+        }
+        return new BsonDocument("ok", new BsonInt32(1));
+    }
+
     BsonDocument getListIndexesResult(final BsonDocument collectionOptions, final BsonDocument arguments,
                                       @Nullable final ClientSession clientSession) {
         ListIndexesIterable<BsonDocument> iterable;

--- a/driver-sync/src/test/functional/com/mongodb/client/WriteConcernOperationTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WriteConcernOperationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.MongoClientSettings;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+// See https://github.com/mongodb/specifications/tree/master/source/transactions/tests
+@RunWith(Parameterized.class)
+public class WriteConcernOperationTest extends AbstractWriteConcernOperationTest {
+    public WriteConcernOperationTest(final String filename, final String description, final String databaseName,
+                                     final String collectionName, final BsonArray data, final BsonDocument definition,
+                                     final boolean skipTest) {
+        super(filename, description, databaseName, collectionName, data, definition, skipTest);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/WriteConcernOperationTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WriteConcernOperationTest.java
@@ -22,7 +22,7 @@ import org.bson.BsonDocument;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-// See https://github.com/mongodb/specifications/tree/master/source/transactions/tests
+// See https://github.com/mongodb/specifications/tree/master/source/read-write-concern/tests/operation
 @RunWith(Parameterized.class)
 public class WriteConcernOperationTest extends AbstractWriteConcernOperationTest {
     public WriteConcernOperationTest(final String filename, final String description, final String databaseName,


### PR DESCRIPTION
JAVA-3499

Evergreen patch: https://evergreen.mongodb.com/version/5e4e22ac61837d50a0056890
Sharded and replica set failures in latest variants are timeouts not due to these changes.