### PR TITLE
Add deprecation annotation for oplogReplay methods

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/AsyncFindIterableImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/AsyncFindIterableImpl.java
@@ -118,6 +118,7 @@ class AsyncFindIterableImpl<TDocument, TResult> extends AsyncMongoIterableImpl<T
     }
 
     @Override
+    @Deprecated
     public AsyncFindIterable<TResult> oplogReplay(final boolean oplogReplay) {
         findOptions.oplogReplay(oplogReplay);
         return this;

--- a/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
@@ -267,6 +267,7 @@ public final class FindOptions {
      *
      * @return if oplog replay is enabled
      */
+    @Deprecated
     public boolean isOplogReplay() {
         return oplogReplay;
     }
@@ -277,6 +278,7 @@ public final class FindOptions {
      * @param oplogReplay if oplog replay is enabled
      * @return this
      */
+    @Deprecated
     public FindOptions oplogReplay(final boolean oplogReplay) {
         this.oplogReplay = oplogReplay;
         return this;

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -376,6 +376,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
      * @return oplogReplay
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
      */
+    @Deprecated
     public boolean isOplogReplay() {
         return oplogReplay;
     }
@@ -387,6 +388,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
      * @return this
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
      */
+    @Deprecated
     public FindOperation<T> oplogReplay(final boolean oplogReplay) {
         this.oplogReplay = oplogReplay;
         return this;

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -364,6 +364,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      * @since 3.9
      * @deprecated oplogReplay has been deprecated in MongoDB 4.4.
      */
+    @Deprecated
     public DBCursor oplogReplay(final boolean oplogReplay) {
         findOptions.oplogReplay(oplogReplay);
         return this;

--- a/driver-legacy/src/main/com/mongodb/client/model/DBCollectionFindOptions.java
+++ b/driver-legacy/src/main/com/mongodb/client/model/DBCollectionFindOptions.java
@@ -298,6 +298,7 @@ public final class DBCollectionFindOptions {
      * @return if oplog replay is enabled
      * @deprecated oplogReplay has been deprecated in MongoDB 4.4.
      */
+    @Deprecated
     public boolean isOplogReplay() {
         return oplogReplay;
     }
@@ -309,6 +310,7 @@ public final class DBCollectionFindOptions {
      * @return this
      * @deprecated oplogReplay has been deprecated in MongoDB 4.4.
      */
+    @Deprecated
     public DBCollectionFindOptions oplogReplay(final boolean oplogReplay) {
         this.oplogReplay = oplogReplay;
         return this;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/FindPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/FindPublisher.java
@@ -128,6 +128,7 @@ public interface FindPublisher<TResult> extends Publisher<TResult> {
      * @return this
      * @deprecated oplogReplay has been deprecated in MongoDB 4.4.
      */
+    @Deprecated
     FindPublisher<TResult> oplogReplay(boolean oplogReplay);
 
     /**

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
@@ -92,6 +92,7 @@ final class FindPublisherImpl<TResult> implements FindPublisher<TResult> {
     }
 
     @Override
+    @Deprecated
     public FindPublisher<TResult> oplogReplay(final boolean oplogReplay) {
         wrapped.oplogReplay(oplogReplay);
         return this;

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncFindIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncFindIterable.java
@@ -82,6 +82,7 @@ class SyncFindIterable<T> extends SyncMongoIterable<T> implements FindIterable<T
     }
 
     @Override
+    @Deprecated
     public FindIterable<T> oplogReplay(final boolean oplogReplay) {
         wrapped.oplogReplay(oplogReplay);
         return this;

--- a/driver-sync/src/main/com/mongodb/client/FindIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/FindIterable.java
@@ -121,6 +121,7 @@ public interface FindIterable<TResult> extends MongoIterable<TResult> {
      * @return this
      * @deprecated oplogReplay has been deprecated in MongoDB 4.4.
      */
+    @Deprecated
     FindIterable<TResult> oplogReplay(boolean oplogReplay);
 
     /**

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -124,6 +124,7 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     }
 
     @Override
+    @Deprecated
     public FindIterable<TResult> oplogReplay(final boolean oplogReplay) {
         findOptions.oplogReplay(oplogReplay);
         return this;


### PR DESCRIPTION
JAVA-3591

Not clear how the annotations got dropped in the previous commit.