### PR TITLE
Update disabled change stream tests

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/async/client/ChangeStreamProseTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/async/client/ChangeStreamProseTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
-import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.internal.async.client.Fixture.getDefaultDatabaseName;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -74,7 +73,6 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testMissingResumeTokenThrowsException() {
-        assumeTrue(serverVersionLessThan(4, 3));
         boolean exceptionFound = false;
         AsyncBatchCursor<ChangeStreamDocument<Document>> cursor =
                 createChangeStreamCursor(collection.watch(singletonList(Aggregates.project(Document.parse("{ _id : 0 }")))));

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -402,7 +402,6 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    @IgnoreIf({ serverVersionAtLeast(4, 3) })
     def 'should throw if the _id field is projected out'() {
         given:
         def helper = getHelper()

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractChangeStreamsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractChangeStreamsTest.java
@@ -29,7 +29,6 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
-import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonDocumentCodec;
 import org.junit.After;
@@ -236,10 +235,6 @@ public abstract class AbstractChangeStreamsTest {
                     testDocument.getString("collection2_name").getValue());
 
             for (BsonValue test : testDocument.getArray("tests")) {
-                if (test.asDocument().getString("description").getValue()
-                        .equals("Change Stream should error when _id is projected out")) {
-                    test.asDocument().put("maxServerVersion", new BsonString("4.2"));
-                }
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
                         namespace, namespace2, test.asDocument(), skipTest(testDocument, test.asDocument())});
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
@@ -123,7 +123,6 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testMissingResumeTokenThrowsException() {
-        assumeTrue(serverVersionLessThan(4, 3));
         boolean exceptionFound = false;
 
         MongoCursor<ChangeStreamDocument<Document>> cursor = collection.watch(asList(Aggregates.project(Document.parse("{ _id : 0 }"))))


### PR DESCRIPTION
JAVA-3625
Some change stream tests were disabled in JAVA-3624 because of failures in the latest server variant. The work that was done on the server depended on by SPEC-1505 resolved the issues for these tests. The tests are now enabled.