### PR TITLE
Support speculative authentication attempts in isMaster

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.ServerAddress;
 import com.mongodb.annotations.Immutable;
+import org.bson.BsonArray;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,7 @@ public class ConnectionDescription {
     private final int maxDocumentSize;
     private final int maxMessageSize;
     private final List<String> compressors;
+    private BsonArray saslSupportedMechanisms;
 
     private static final int DEFAULT_MAX_MESSAGE_SIZE = 0x2000000;   // 32MB
     private static final int DEFAULT_MAX_WRITE_BATCH_SIZE = 512;
@@ -50,8 +52,18 @@ public class ConnectionDescription {
      * @param serverId   the server address
      */
     public ConnectionDescription(final ServerId serverId) {
-        this(new ConnectionId(serverId), 0, ServerType.UNKNOWN, DEFAULT_MAX_WRITE_BATCH_SIZE,
-             getDefaultMaxDocumentSize(), DEFAULT_MAX_MESSAGE_SIZE, Collections.<String>emptyList());
+        this(serverId, 0);
+    }
+
+    /**
+     * Construct a defaulted connection description instance.
+     *
+     * @param serverId   the server address
+     * @param maxWireVersion the max wire version
+     */
+    public ConnectionDescription(final ServerId serverId, final int maxWireVersion) {
+        this(new ConnectionId(serverId), maxWireVersion, ServerType.UNKNOWN, DEFAULT_MAX_WRITE_BATCH_SIZE,
+                getDefaultMaxDocumentSize(), DEFAULT_MAX_MESSAGE_SIZE, Collections.<String>emptyList());
     }
 
     /**
@@ -162,6 +174,24 @@ public class ConnectionDescription {
      */
     public List<String> getCompressors() {
         return compressors;
+    }
+
+    /**
+     * Get the supported SASL mechanisms.
+     *
+     * @return the supported SASL mechanisms.
+     */
+    public BsonArray getSaslSupportedMechanisms() {
+        return saslSupportedMechanisms;
+    }
+
+    /**
+     * Set the supported SASL mechanisms.
+     *
+     * @param saslSupportedMechanisms the supported SASL mechanisms
+     */
+    public void setSaslSupportedMechanisms(final BsonArray saslSupportedMechanisms) {
+        this.saslSupportedMechanisms = saslSupportedMechanisms;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
@@ -110,19 +110,6 @@ public class ConnectionDescription {
     public ConnectionDescription withConnectionId(final ConnectionId connectionId) {
         notNull("connectionId", connectionId);
         return new ConnectionDescription(connectionId, maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize,
-                compressors);
-    }
-
-    /**
-     * Creates a new connection description with the supported SASL mechanisms
-     *
-     * @param saslSupportedMechanisms the supported SASL mechanisms
-     * @return the new connection description
-     * @since 4.1
-     */
-    public ConnectionDescription withSaslSupportedMechanisms(final BsonArray saslSupportedMechanisms) {
-        notNull("connectionId", connectionId);
-        return new ConnectionDescription(connectionId, maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize,
                 compressors, saslSupportedMechanisms);
     }
 

--- a/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
@@ -41,7 +41,7 @@ public class ConnectionDescription {
     private final int maxDocumentSize;
     private final int maxMessageSize;
     private final List<String> compressors;
-    private BsonArray saslSupportedMechanisms;
+    private final BsonArray saslSupportedMechanisms;
 
     private static final int DEFAULT_MAX_MESSAGE_SIZE = 0x2000000;   // 32MB
     private static final int DEFAULT_MAX_WRITE_BATCH_SIZE = 512;
@@ -52,18 +52,8 @@ public class ConnectionDescription {
      * @param serverId   the server address
      */
     public ConnectionDescription(final ServerId serverId) {
-        this(serverId, 0);
-    }
-
-    /**
-     * Construct a defaulted connection description instance.
-     *
-     * @param serverId   the server address
-     * @param maxWireVersion the max wire version
-     */
-    public ConnectionDescription(final ServerId serverId, final int maxWireVersion) {
-        this(new ConnectionId(serverId), maxWireVersion, ServerType.UNKNOWN, DEFAULT_MAX_WRITE_BATCH_SIZE,
-                getDefaultMaxDocumentSize(), DEFAULT_MAX_MESSAGE_SIZE, Collections.<String>emptyList());
+        this(new ConnectionId(serverId), 0, ServerType.UNKNOWN, DEFAULT_MAX_WRITE_BATCH_SIZE,
+             getDefaultMaxDocumentSize(), DEFAULT_MAX_MESSAGE_SIZE, Collections.<String>emptyList());
     }
 
     /**
@@ -81,6 +71,25 @@ public class ConnectionDescription {
     public ConnectionDescription(final ConnectionId connectionId, final int maxWireVersion,
                                  final ServerType serverType, final int maxBatchCount, final int maxDocumentSize,
                                  final int maxMessageSize, final List<String> compressors) {
+        this(connectionId, maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize, compressors, null);
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param connectionId    the connection id
+     * @param maxWireVersion  the max wire version
+     * @param serverType      the server type
+     * @param maxBatchCount   the max batch count
+     * @param maxDocumentSize the max document size in bytes
+     * @param maxMessageSize  the max message size in bytes
+     * @param compressors     the available compressors on the connection
+     * @param saslSupportedMechanisms the supported SASL mechanisms
+     * @since 4.1
+     */
+    public ConnectionDescription(final ConnectionId connectionId, final int maxWireVersion,
+                                 final ServerType serverType, final int maxBatchCount, final int maxDocumentSize,
+                                 final int maxMessageSize, final List<String> compressors, final BsonArray saslSupportedMechanisms) {
         this.connectionId = connectionId;
         this.serverType = serverType;
         this.maxBatchCount = maxBatchCount;
@@ -88,6 +97,7 @@ public class ConnectionDescription {
         this.maxMessageSize = maxMessageSize;
         this.maxWireVersion = maxWireVersion;
         this.compressors = notNull("compressors", Collections.unmodifiableList(new ArrayList<String>(compressors)));
+        this.saslSupportedMechanisms = saslSupportedMechanisms;
     }
 
     /**
@@ -101,6 +111,19 @@ public class ConnectionDescription {
         notNull("connectionId", connectionId);
         return new ConnectionDescription(connectionId, maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize,
                 compressors);
+    }
+
+    /**
+     * Creates a new connection description with the supported SASL mechanisms
+     *
+     * @param saslSupportedMechanisms the supported SASL mechanisms
+     * @return the new connection description
+     * @since 4.1
+     */
+    public ConnectionDescription withSaslSupportedMechanisms(final BsonArray saslSupportedMechanisms) {
+        notNull("connectionId", connectionId);
+        return new ConnectionDescription(connectionId, maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize,
+                compressors, saslSupportedMechanisms);
     }
 
     /**
@@ -180,18 +203,10 @@ public class ConnectionDescription {
      * Get the supported SASL mechanisms.
      *
      * @return the supported SASL mechanisms.
+     * @since 4.1
      */
     public BsonArray getSaslSupportedMechanisms() {
         return saslSupportedMechanisms;
-    }
-
-    /**
-     * Set the supported SASL mechanisms.
-     *
-     * @param saslSupportedMechanisms the supported SASL mechanisms
-     */
-    public void setSaslSupportedMechanisms(final BsonArray saslSupportedMechanisms) {
-        this.saslSupportedMechanisms = saslSupportedMechanisms;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultAuthenticator.java
@@ -23,21 +23,20 @@ import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.connection.ConnectionDescription;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.bson.BsonString;
 
+import static com.mongodb.AuthenticationMechanism.MONGODB_X509;
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_1;
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_256;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
-import static com.mongodb.internal.connection.CommandHelper.executeCommand;
-import static com.mongodb.internal.connection.CommandHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionFourDotZero;
 import static java.lang.String.format;
 
-class DefaultAuthenticator extends Authenticator {
+class DefaultAuthenticator extends SpeculativeAuthenticator {
     static final int USER_NOT_FOUND_CODE = 11;
     private static final BsonString DEFAULT_MECHANISM_NAME = new BsonString(SCRAM_SHA_256.getMechanismName());
+    private SpeculativeAuthenticator speculativeAuthenticator;
 
     DefaultAuthenticator(final MongoCredentialWithCache credential) {
         super(credential);
@@ -51,9 +50,8 @@ class DefaultAuthenticator extends Authenticator {
                     .authenticate(connection, connectionDescription);
         } else {
             try {
-                BsonDocument isMasterResult = executeCommand("admin", createIsMasterCommand(), connection);
-                getAuthenticatorFromIsMasterResult(isMasterResult, connectionDescription)
-                        .authenticate(connection, connectionDescription);
+                setSpeculativeAuthenticator(connectionDescription);
+                speculativeAuthenticator.authenticate(connection, connectionDescription);
             } catch (Exception e) {
                 throw wrapException(e);
             }
@@ -67,28 +65,28 @@ class DefaultAuthenticator extends Authenticator {
             getLegacyDefaultAuthenticator(connectionDescription)
                     .authenticateAsync(connection, connectionDescription, callback);
         } else {
-            executeCommandAsync("admin", createIsMasterCommand(), connection, new SingleResultCallback<BsonDocument>() {
-                @Override
-                public void onResult(final BsonDocument result, final Throwable t) {
-                    if (t != null) {
-                        callback.onResult(null, wrapException(t));
-                    } else {
-                        getAuthenticatorFromIsMasterResult(result, connectionDescription)
-                                .authenticateAsync(connection, connectionDescription, callback);
-                    }
-                }
-            });
+            setSpeculativeAuthenticator(connectionDescription);
+            speculativeAuthenticator.authenticateAsync(connection, connectionDescription, callback);
         }
     }
 
-    Authenticator getAuthenticatorFromIsMasterResult(final BsonDocument isMasterResult, final ConnectionDescription connectionDescription) {
-        if (isMasterResult.containsKey("saslSupportedMechs")) {
-            BsonArray saslSupportedMechs = isMasterResult.getArray("saslSupportedMechs");
-            AuthenticationMechanism mechanism = saslSupportedMechs.contains(DEFAULT_MECHANISM_NAME) ? SCRAM_SHA_256 : SCRAM_SHA_1;
-            return new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(mechanism));
-        } else {
-            return getLegacyDefaultAuthenticator(connectionDescription);
+    @Override
+    public BsonDocument createSpeculativeAuthenticateCommand(final InternalConnection connection) {
+        speculativeAuthenticator = getAuthenticatorForIsMaster();
+        return speculativeAuthenticator != null ? speculativeAuthenticator.createSpeculativeAuthenticateCommand(connection) : null;
+    }
+
+    @Override
+    public BsonDocument getSpeculativeAuthenticateResponse() {
+        if (speculativeAuthenticator != null) {
+            return speculativeAuthenticator.getSpeculativeAuthenticateResponse();
         }
+        return null;
+    }
+
+    @Override
+    public void setSpeculativeAuthenticateResponse(final BsonDocument response) {
+        speculativeAuthenticator.setSpeculativeAuthenticateResponse(response);
     }
 
     private Authenticator getLegacyDefaultAuthenticator(final ConnectionDescription connectionDescription) {
@@ -99,11 +97,27 @@ class DefaultAuthenticator extends Authenticator {
         }
     }
 
-    private BsonDocument createIsMasterCommand() {
-        BsonDocument isMasterCommandDocument = new BsonDocument("ismaster", new BsonInt32(1));
-        isMasterCommandDocument.append("saslSupportedMechs",
-                new BsonString(format("%s.%s", getMongoCredential().getSource(), getMongoCredential().getUserName())));
-        return isMasterCommandDocument;
+    protected SpeculativeAuthenticator getAuthenticatorForIsMaster() {
+        AuthenticationMechanism mechanism = getMongoCredential().getAuthenticationMechanism();
+
+        if (mechanism == null) {
+            return new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(SCRAM_SHA_256));
+        } else if (mechanism.equals(SCRAM_SHA_1) || mechanism.equals(SCRAM_SHA_256)) {
+            return new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(mechanism));
+        } else if (mechanism.equals(MONGODB_X509)) {
+            return new X509Authenticator(getMongoCredentialWithCache().withMechanism(mechanism));
+        }
+        return null;
+    }
+
+    private void setSpeculativeAuthenticator(final ConnectionDescription connectionDescription) {
+        BsonArray saslSupportedMechanisms = connectionDescription.getSaslSupportedMechanisms();
+        AuthenticationMechanism mechanism = saslSupportedMechanisms == null || saslSupportedMechanisms.contains(DEFAULT_MECHANISM_NAME)
+                ? SCRAM_SHA_256 : SCRAM_SHA_1;
+
+        if (speculativeAuthenticator == null || speculativeAuthenticator.getMongoCredential().getAuthenticationMechanism() != mechanism) {
+            speculativeAuthenticator = new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(mechanism));
+        }
     }
 
     private MongoException wrapException(final Throwable t) {

--- a/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
@@ -67,7 +67,7 @@ public final class DescriptionHelper {
             connectionDescription = connectionDescription.withConnectionId(newConnectionId);
         }
         if (isMasterResult.containsKey("saslSupportedMechs")) {
-            connectionDescription.setSaslSupportedMechanisms(isMasterResult.getArray("saslSupportedMechs"));
+            connectionDescription = connectionDescription.withSaslSupportedMechanisms(isMasterResult.getArray("saslSupportedMechs"));
         }
         return connectionDescription;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
@@ -66,6 +66,9 @@ public final class DescriptionHelper {
                     connectionDescription.getConnectionId().withServerValue(isMasterResult.getNumber("connectionId").intValue());
             connectionDescription = connectionDescription.withConnectionId(newConnectionId);
         }
+        if (isMasterResult.containsKey("saslSupportedMechs")) {
+            connectionDescription.setSaslSupportedMechanisms(isMasterResult.getArray("saslSupportedMechs"));
+        }
         return connectionDescription;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
@@ -60,14 +60,12 @@ public final class DescriptionHelper {
                                                              final BsonDocument isMasterResult) {
         ConnectionDescription connectionDescription = new ConnectionDescription(connectionId,
                 getMaxWireVersion(isMasterResult), getServerType(isMasterResult), getMaxWriteBatchSize(isMasterResult),
-                getMaxBsonObjectSize(isMasterResult), getMaxMessageSizeBytes(isMasterResult), getCompressors(isMasterResult));
+                getMaxBsonObjectSize(isMasterResult), getMaxMessageSizeBytes(isMasterResult), getCompressors(isMasterResult),
+                isMasterResult.getArray("saslSupportedMechs", null));
         if (isMasterResult.containsKey("connectionId")) {
             ConnectionId newConnectionId =
                     connectionDescription.getConnectionId().withServerValue(isMasterResult.getNumber("connectionId").intValue());
             connectionDescription = connectionDescription.withConnectionId(newConnectionId);
-        }
-        if (isMasterResult.containsKey("saslSupportedMechs")) {
-            connectionDescription = connectionDescription.withSaslSupportedMechanisms(isMasterResult.getArray("saslSupportedMechs"));
         }
         return connectionDescription;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
@@ -31,9 +31,9 @@ import static com.mongodb.internal.connection.ClientMetadataHelper.createClientM
 class InternalStreamConnectionFactory implements InternalConnectionFactory {
     private final StreamFactory streamFactory;
     private final BsonDocument clientMetadataDocument;
-    private final Authenticator authenticator;
     private final List<MongoCompressor> compressorList;
     private final CommandListener commandListener;
+    private final MongoCredentialWithCache credential;
 
     InternalStreamConnectionFactory(final StreamFactory streamFactory, final MongoCredentialWithCache credential,
                                     final String applicationName, final MongoDriverInformation mongoDriverInformation,
@@ -43,11 +43,12 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
         this.compressorList = notNull("compressorList", compressorList);
         this.commandListener = commandListener;
         this.clientMetadataDocument = createClientMetadataDocument(applicationName, mongoDriverInformation);
-        authenticator = credential == null ? null : createAuthenticator(credential);
+        this.credential = credential;
     }
 
     @Override
     public InternalConnection create(final ServerId serverId) {
+        Authenticator authenticator = credential == null ? null : createAuthenticator(credential);
         return new InternalStreamConnection(serverId, streamFactory, compressorList, commandListener,
                                             new InternalStreamConnectionInitializer(authenticator, clientMetadataDocument,
                                                                                            compressorList));

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -97,7 +97,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
     private ConnectionDescription initializeConnectionDescription(final InternalConnection internalConnection) {
         BsonDocument isMasterResult;
-        BsonDocument isMasterCommandDocument = createIsMasterCommand();
+        BsonDocument isMasterCommandDocument = createIsMasterCommand(authenticator, internalConnection);
 
         try {
             isMasterResult = executeCommand("admin", isMasterCommandDocument, internalConnection);
@@ -111,11 +111,11 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
         ConnectionDescription connectionDescription = createConnectionDescription(internalConnection.getDescription().getConnectionId(),
                 isMasterResult);
-        setAuthenticator(isMasterResult, connectionDescription);
+        setSpeculativeAuthenticateResponse(isMasterResult);
         return connectionDescription;
     }
 
-    private BsonDocument createIsMasterCommand() {
+    private BsonDocument createIsMasterCommand(final Authenticator authenticator, final InternalConnection connection) {
         BsonDocument isMasterCommandDocument = new BsonDocument("ismaster", new BsonInt32(1));
         if (clientMetadataDocument != null) {
             isMasterCommandDocument.append("client", clientMetadataDocument);
@@ -131,6 +131,13 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
             MongoCredential credential = authenticator.getMongoCredential();
             isMasterCommandDocument.append("saslSupportedMechs",
                     new BsonString(credential.getSource() + "." + credential.getUserName()));
+        }
+        if (authenticator instanceof SpeculativeAuthenticator) {
+            BsonDocument speculativeAuthenticateDocument =
+                    ((SpeculativeAuthenticator) authenticator).createSpeculativeAuthenticateCommand(connection);
+            if (speculativeAuthenticateDocument != null) {
+                isMasterCommandDocument.append("speculativeAuthenticate", speculativeAuthenticateDocument);
+            }
         }
         return isMasterCommandDocument;
     }
@@ -155,7 +162,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
     private void initializeConnectionDescriptionAsync(final InternalConnection internalConnection,
                                                       final SingleResultCallback<ConnectionDescription> callback) {
-        executeCommandAsync("admin", createIsMasterCommand(), internalConnection,
+        executeCommandAsync("admin", createIsMasterCommand(authenticator, internalConnection), internalConnection,
                 new SingleResultCallback<BsonDocument>() {
                     @Override
                     public void onResult(final BsonDocument isMasterResult, final Throwable t) {
@@ -171,17 +178,17 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                         } else {
                             ConnectionId connectionId = internalConnection.getDescription().getConnectionId();
                             ConnectionDescription connectionDescription = createConnectionDescription(connectionId, isMasterResult);
-                            setAuthenticator(isMasterResult, connectionDescription);
+                            setSpeculativeAuthenticateResponse(isMasterResult);
                             callback.onResult(connectionDescription, null);
                         }
                     }
                 });
     }
 
-    private void setAuthenticator(final BsonDocument isMasterResult, final ConnectionDescription connectionDescription) {
-        if (checkSaslSupportedMechs) {
-            authenticator = ((DefaultAuthenticator) authenticator).getAuthenticatorFromIsMasterResult(isMasterResult,
-                    connectionDescription);
+    private void setSpeculativeAuthenticateResponse(final BsonDocument isMasterResult) {
+        if (authenticator instanceof SpeculativeAuthenticator) {
+            ((SpeculativeAuthenticator) authenticator).setSpeculativeAuthenticateResponse(
+                    isMasterResult.getDocument("speculativeAuthenticate", null));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
@@ -37,7 +37,7 @@ import static com.mongodb.MongoCredential.JAVA_SUBJECT_KEY;
 import static com.mongodb.internal.connection.CommandHelper.executeCommand;
 import static com.mongodb.internal.connection.CommandHelper.executeCommandAsync;
 
-abstract class SaslAuthenticator extends SpeculativeAuthenticator {
+abstract class SaslAuthenticator extends Authenticator implements SpeculativeAuthenticator {
     SaslAuthenticator(final MongoCredentialWithCache credential) {
         super(credential);
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
@@ -37,8 +37,7 @@ import static com.mongodb.MongoCredential.JAVA_SUBJECT_KEY;
 import static com.mongodb.internal.connection.CommandHelper.executeCommand;
 import static com.mongodb.internal.connection.CommandHelper.executeCommandAsync;
 
-abstract class SaslAuthenticator extends Authenticator {
-
+abstract class SaslAuthenticator extends SpeculativeAuthenticator {
     SaslAuthenticator(final MongoCredentialWithCache credential) {
         super(credential);
     }
@@ -50,13 +49,11 @@ abstract class SaslAuthenticator extends Authenticator {
                 SaslClient saslClient = createSaslClient(connection.getDescription().getServerAddress());
                 throwIfSaslClientIsNull(saslClient);
                 try {
-                    byte[] response = (saslClient.hasInitialResponse() ? saslClient.evaluateChallenge(new byte[0]) : null);
-                    BsonDocument res = sendSaslStart(response, connection);
+                    BsonDocument responseDocument = getNextSaslResponse(saslClient, connection);
+                    BsonInt32 conversationId = responseDocument.getInt32("conversationId");
 
-                    BsonInt32 conversationId = res.getInt32("conversationId");
-
-                    while (!(res.getBoolean("done")).getValue()) {
-                        response = saslClient.evaluateChallenge((res.getBinary("payload")).getData());
+                    while (!(responseDocument.getBoolean("done")).getValue()) {
+                        byte[] response = saslClient.evaluateChallenge((responseDocument.getBinary("payload")).getData());
 
                         if (response == null) {
                             throw new MongoSecurityException(getMongoCredential(),
@@ -64,10 +61,10 @@ abstract class SaslAuthenticator extends Authenticator {
                                             + getMongoCredential());
                         }
 
-                        res = sendSaslContinue(conversationId, response, connection);
+                        responseDocument = sendSaslContinue(conversationId, response, connection);
                     }
                     if (!saslClient.isComplete()) {
-                        saslClient.evaluateChallenge((res.getBinary("payload")).getData());
+                        saslClient.evaluateChallenge((responseDocument.getBinary("payload")).getData());
                         if (!saslClient.isComplete()) {
                             throw new MongoSecurityException(getMongoCredential(),
                                     "SASL protocol error: server completed challenges before client completed responses "
@@ -93,23 +90,7 @@ abstract class SaslAuthenticator extends Authenticator {
                 public Void run() {
                     final SaslClient saslClient = createSaslClient(connection.getDescription().getServerAddress());
                     throwIfSaslClientIsNull(saslClient);
-                    try {
-                        byte[] response = (saslClient.hasInitialResponse() ? saslClient.evaluateChallenge(new byte[0]) : null);
-                        sendSaslStartAsync(response, connection, new SingleResultCallback<BsonDocument>() {
-                            @Override
-                            public void onResult(final BsonDocument result, final Throwable t) {
-                                if (t != null) {
-                                    callback.onResult(null, wrapException(t));
-                                } else if (result.getBoolean("done").getValue()) {
-                                    verifySaslClientComplete(saslClient, result, callback);
-                                } else {
-                                    new Continuator(saslClient, result, connection, callback).start();
-                                }
-                            }
-                        });
-                    } catch (SaslException e) {
-                        throw wrapException(e);
-                    }
+                    getNextSaslResponseAsync(saslClient, connection, callback);
                     return null;
                 }
             });
@@ -128,6 +109,50 @@ abstract class SaslAuthenticator extends Authenticator {
         if (saslClient == null) {
             throw new MongoSecurityException(getMongoCredential(),
                     String.format("This JDK does not support the %s SASL mechanism", getMechanismName()));
+        }
+    }
+
+    private BsonDocument getNextSaslResponse(final SaslClient saslClient, final InternalConnection connection) {
+        BsonDocument response = getSpeculativeAuthenticateResponse();
+        if (response != null) {
+            return response;
+        }
+
+        try {
+            byte[] serverResponse = saslClient.hasInitialResponse() ? saslClient.evaluateChallenge(new byte[0]) : null;
+            return sendSaslStart(serverResponse, connection);
+        } catch (Exception e) {
+            throw wrapException(e);
+        }
+    }
+
+    private void getNextSaslResponseAsync(final SaslClient saslClient, final InternalConnection connection,
+                                          final SingleResultCallback<Void> callback) {
+        BsonDocument authenticateResponse = getSpeculativeAuthenticateResponse();
+        try {
+            if (authenticateResponse == null) {
+                byte[] response = (saslClient.hasInitialResponse() ? saslClient.evaluateChallenge(new byte[0]) : null);
+                sendSaslStartAsync(response, connection, new SingleResultCallback<BsonDocument>() {
+                    @Override
+                    public void onResult(final BsonDocument result, final Throwable t) {
+                        if (t != null) {
+                            callback.onResult(null, wrapException(t));
+                        } else if (result.getBoolean("done").getValue()) {
+                            verifySaslClientComplete(saslClient, result, callback);
+                        } else {
+                            new Continuator(saslClient, result, connection, callback).start();
+                        }
+                    }
+                });
+            } else {
+                if (authenticateResponse.getBoolean("done").getValue()) {
+                    verifySaslClientComplete(saslClient, authenticateResponse, callback);
+                } else {
+                    new Continuator(saslClient, authenticateResponse, connection, callback).start();
+                }
+            }
+        } catch (Exception e) {
+            throw wrapException(e);
         }
     }
 
@@ -179,7 +204,7 @@ abstract class SaslAuthenticator extends Authenticator {
                 callback);
     }
 
-    private BsonDocument createSaslStartCommandDocument(final byte[] outToken) {
+    protected BsonDocument createSaslStartCommandDocument(final byte[] outToken) {
         return new BsonDocument("saslStart", new BsonInt32(1)).append("mechanism", new BsonString(getMechanismName()))
                 .append("payload", new BsonBinary(outToken != null ? outToken : new byte[0]));
     }
@@ -197,7 +222,7 @@ abstract class SaslAuthenticator extends Authenticator {
         }
     }
 
-    private MongoException wrapException(final Throwable t) {
+    protected MongoException wrapException(final Throwable t) {
         if (t instanceof MongoInterruptedException) {
             return (MongoInterruptedException) t;
         } else if (t instanceof MongoSecurityException) {

--- a/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
@@ -22,6 +22,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.internal.authentication.SaslPrep;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.internal.Base64;
 
 import javax.crypto.Mac;
@@ -44,6 +45,8 @@ import static java.lang.String.format;
 class ScramShaAuthenticator extends SaslAuthenticator {
     private final RandomStringGenerator randomStringGenerator;
     private final AuthenticationHashGenerator authenticationHashGenerator;
+    private SaslClient speculativeSaslClient;
+    private BsonDocument speculativeAuthenticateResponse;
 
     private static final int MINIMUM_ITERATION_COUNT = 4096;
     private static final String GS2_HEADER = "n,,";
@@ -82,7 +85,36 @@ class ScramShaAuthenticator extends SaslAuthenticator {
 
     @Override
     protected SaslClient createSaslClient(final ServerAddress serverAddress) {
+        if (speculativeSaslClient != null) {
+            return speculativeSaslClient;
+        }
         return new ScramShaSaslClient(getMongoCredentialWithCache(), randomStringGenerator, authenticationHashGenerator);
+    }
+
+    @Override
+    public BsonDocument createSpeculativeAuthenticateCommand(final InternalConnection connection) {
+        try {
+            speculativeSaslClient = createSaslClient(connection.getDescription().getServerAddress());
+            BsonDocument startDocument = createSaslStartCommandDocument(speculativeSaslClient.evaluateChallenge(new byte[0]))
+                    .append("db", new BsonString("admin"));
+            appendSaslStartOptions(startDocument);
+            return startDocument;
+        } catch (Exception e) {
+            throw wrapException(e);
+        }
+    }
+
+    @Override
+    public BsonDocument getSpeculativeAuthenticateResponse() {
+        return this.speculativeAuthenticateResponse;
+    }
+
+    @Override
+    public void setSpeculativeAuthenticateResponse(final BsonDocument response) {
+        this.speculativeAuthenticateResponse = response;
+        if (response == null) {
+            speculativeSaslClient = null;
+        }
     }
 
     class ScramShaSaslClient implements SaslClient {

--- a/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
@@ -106,14 +106,15 @@ class ScramShaAuthenticator extends SaslAuthenticator {
 
     @Override
     public BsonDocument getSpeculativeAuthenticateResponse() {
-        return this.speculativeAuthenticateResponse;
+        return speculativeAuthenticateResponse;
     }
 
     @Override
     public void setSpeculativeAuthenticateResponse(final BsonDocument response) {
-        this.speculativeAuthenticateResponse = response;
         if (response == null) {
             speculativeSaslClient = null;
+        } else {
+            speculativeAuthenticateResponse = response;
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/SpeculativeAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SpeculativeAuthenticator.java
@@ -18,19 +18,15 @@ package com.mongodb.internal.connection;
 
 import org.bson.BsonDocument;
 
-public abstract class SpeculativeAuthenticator extends Authenticator {
+interface SpeculativeAuthenticator {
 
-    SpeculativeAuthenticator(final MongoCredentialWithCache credential) {
-        super(credential);
-    }
-
-    public BsonDocument createSpeculativeAuthenticateCommand(final InternalConnection connection) {
+    default BsonDocument createSpeculativeAuthenticateCommand(final InternalConnection connection) {
         return null;
     }
 
-    public BsonDocument getSpeculativeAuthenticateResponse() {
+    default BsonDocument getSpeculativeAuthenticateResponse() {
         return null;
     }
 
-    public void setSpeculativeAuthenticateResponse(final BsonDocument response) {}
+    default void setSpeculativeAuthenticateResponse(final BsonDocument response) {}
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/SpeculativeAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SpeculativeAuthenticator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import org.bson.BsonDocument;
+
+public abstract class SpeculativeAuthenticator extends Authenticator {
+
+    SpeculativeAuthenticator(final MongoCredentialWithCache credential) {
+        super(credential);
+    }
+
+    public BsonDocument createSpeculativeAuthenticateCommand(final InternalConnection connection) {
+        return null;
+    }
+
+    public BsonDocument getSpeculativeAuthenticateResponse() {
+        return null;
+    }
+
+    public void setSpeculativeAuthenticateResponse(final BsonDocument response) {}
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ScramShaAuthenticatorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ScramShaAuthenticatorSpecification.groovy
@@ -24,12 +24,14 @@ import com.mongodb.connection.ConnectionDescription
 import com.mongodb.connection.ServerId
 import org.bson.BsonDocument
 import org.bson.internal.Base64
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import javax.security.sasl.SaslException
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.MongoCredential.createScramSha1Credential
 import static com.mongodb.MongoCredential.createScramSha256Credential
 import static org.junit.Assert.assertEquals
@@ -66,6 +68,31 @@ class ScramShaAuthenticatorSpecification extends Specification {
         [async, emptyExchange] << [[true, false], [true, false]].combinations()
     }
 
+    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    def 'should speculatively authenticate with sha1'() {
+        given:
+        def user = 'user'
+        def password = 'pencil'
+        def preppedPassword = 'pencil'
+        def payloads = '''
+            C: c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=
+            S: v=rmF9pqV8S7suAoZWja4dJRkFsKQ=
+        '''
+        def serverResponse = 'r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096'
+        def speculativeAuthenticateResponse =
+                BsonDocument.parse("{ conversationId: 1, payload: BinData(0, '${encode64(serverResponse)}'), done: false }")
+
+        when:
+        def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
+        def authenticator = new ScramShaAuthenticator(credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { preppedPassword })
+
+        then:
+        validateSpeculativeAuthentication(payloads, authenticator, async, speculativeAuthenticateResponse)
+
+        where:
+        async << [true, false]
+    }
+
     def 'should successfully authenticate with sha256 as per RFC spec'() {
         given:
         def user = 'user'
@@ -89,6 +116,30 @@ class ScramShaAuthenticatorSpecification extends Specification {
         [async, emptyExchange] << [[true, false], [true, false]].combinations()
     }
 
+    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    def 'should speculatively authenticate with sha256'() {
+        given:
+        def user = 'user'
+        def password = 'pencil'
+        def preppedPassword = 'pencil'
+        def payloads = '''
+            C: c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=
+            S: v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=
+        '''
+        def serverResponse = 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+        def speculativeAuthenticateResponse =
+                BsonDocument.parse("{ conversationId: 1, payload: BinData(0, '${encode64(serverResponse)}'), done: false }")
+
+        when:
+        def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { preppedPassword })
+
+        then:
+        validateSpeculativeAuthentication(payloads, authenticator, async, speculativeAuthenticateResponse)
+
+        where:
+        async << [true, false]
+    }
 
     def 'should successfully authenticate with SHA-1 ASCII'() {
         given:
@@ -422,13 +473,14 @@ class ScramShaAuthenticatorSpecification extends Specification {
         connection
     }
 
-    def validateClientMessages(TestInternalConnection connection, List<String> clientMessages, String mechanism) {
+    def validateClientMessages(TestInternalConnection connection, List<String> clientMessages, String mechanism,
+                               boolean speculativeAuthenticate = false) {
         def sent = connection.getSent().collect { MessageHelper.decodeCommand( it ) }
         assert(clientMessages.size() == sent.size())
         sent.indices.each {
             def sentMessage = sent.get(it)
-            def messageStart = it == 0 ? "saslStart: 1, mechanism:'$mechanism', options: {skipEmptyExchange: true}"
-                    : 'saslContinue: 1, conversationId: 1'
+            def messageStart = speculativeAuthenticate || it != 0 ? 'saslContinue: 1, conversationId: 1'
+                    : "saslStart: 1, mechanism:'$mechanism', options: {skipEmptyExchange: true}"
             def expectedMessage = BsonDocument.parse("{$messageStart, payload: BinData(0, '${encode64(clientMessages.get(it))}')}")
             assertEquals(expectedMessage, sentMessage)
         }
@@ -440,6 +492,17 @@ class ScramShaAuthenticatorSpecification extends Specification {
         def connection = createConnection(serverResponses, emptyExchange ? -1 : 1)
         authenticate(connection, authenticator, async)
         validateClientMessages(connection, clientMessages, authenticator.getMechanismName())
+    }
+
+    def validateSpeculativeAuthentication(String payloads, ScramShaAuthenticator authenticator, boolean async,
+                                          BsonDocument speculativeAuthenticateResponse) {
+        def (clientMessages, serverResponses) = createMessages(payloads, false)
+        def connection = createConnection(serverResponses, 0)
+        authenticator.createSpeculativeAuthenticateCommand(connection)
+        authenticator.setSpeculativeAuthenticateResponse(speculativeAuthenticateResponse)
+
+        authenticate(connection, authenticator, async)
+        validateClientMessages(connection, clientMessages, authenticator.getMechanismName(), true)
     }
 
     def authenticate(TestInternalConnection connection, ScramShaAuthenticator authenticator, boolean async) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
@@ -57,7 +57,11 @@ class TestInternalConnection implements InternalConnection {
     private boolean closed;
 
     TestInternalConnection(final ServerId serverId) {
-        this.description = new ConnectionDescription(serverId);
+        this(serverId, 0);
+    }
+
+    TestInternalConnection(final ServerId serverId, final int maxWireVersion) {
+        this.description = new ConnectionDescription(serverId, maxWireVersion);
         this.bufferProvider = new SimpleBufferProvider();
 
         this.replies = new LinkedList<Interaction>();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
@@ -17,6 +17,8 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.MongoException;
+import com.mongodb.connection.ConnectionId;
+import com.mongodb.connection.ServerType;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.connection.BufferProvider;
 import com.mongodb.connection.ConnectionDescription;
@@ -34,6 +36,7 @@ import org.bson.io.ByteBufferBsonInput;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -57,11 +60,8 @@ class TestInternalConnection implements InternalConnection {
     private boolean closed;
 
     TestInternalConnection(final ServerId serverId) {
-        this(serverId, 0);
-    }
-
-    TestInternalConnection(final ServerId serverId, final int maxWireVersion) {
-        this.description = new ConnectionDescription(serverId, maxWireVersion);
+        this.description = new ConnectionDescription(new ConnectionId(serverId), 0, ServerType.UNKNOWN, 0, 0, 0,
+                Collections.<String>emptyList());
         this.bufferProvider = new SimpleBufferProvider();
 
         this.replies = new LinkedList<Interaction>();


### PR DESCRIPTION
JAVA-3652
Evergreen patch: https://evergreen.mongodb.com/version/5e7a52943627e0034e09fbc5

The authentication mechanism used in Evergreen for 4.4 seems to be set to SCRAM-SHA-1, but the default authentication mechanism used for speculative authentication is SCRAM-SHA-256. The documentation for 4.4 does not state explicitly that SCRAM-SHA-256 is the default mechanism for authentication, but that was the suggestion I received from the server team. Looking at the orchestration project, only authentication for AWS sets the parameter `authenticationParameters`. I did not find any other configuration files where the authentication parameter is set.