### PR TITLE
Add SDAM test for incompatible server becoming compatible

### DIFF
--- a/driver-core/src/test/resources/server-discovery-and-monitoring/single/too_old_then_upgraded.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/single/too_old_then_upgraded.json
@@ -1,0 +1,54 @@
+{
+  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
JAVA-3663
Evergreen patch: https://evergreen.mongodb.com/version/5e85769ad1fe07045073697a