### PR TITLE
Ensure that the WriteConcernError errInfo object is propagated

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/async/client/WriteConcernProseTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/async/client/WriteConcernProseTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async.client;
+
+import com.mongodb.MongoException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.MongoWriteConcernException;
+import com.mongodb.async.FutureResultCallback;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.test.CollectionHelper;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.internal.async.client.Fixture.getDefaultDatabaseName;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+// See https://github.com/mongodb/specifications/tree/master/source/change-streams/tests/README.rst#prose-tests
+public class WriteConcernProseTest extends DatabaseTestCase {
+    private BsonDocument failPointDocument;
+    private CollectionHelper<Document> collectionHelper;
+
+    @Before
+    @Override
+    public void setUp() {
+        assumeTrue(canRunTests());
+        super.setUp();
+        collectionHelper = new CollectionHelper<>(new DocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), "test"));
+    }
+
+    // Ensure that the WriteConcernError errInfo object is propagated.
+    @Test
+    public void testWriteConcernErrInfoIsPropagated() {
+        try {
+            setFailPoint();
+            insertOneDocument();
+        } catch (MongoWriteConcernException e) {
+            assertEquals(e.getWriteConcernError().getCode(), 100);
+            assertTrue(e.getWriteConcernError().getCodeName().equals("UnsatisfiableWriteConcern"));
+            assertEquals(e.getWriteConcernError().getDetails(), new BsonDocument("writeConcern",
+                    new BsonDocument("w", new BsonInt32(2))
+                            .append("wtimeout", new BsonInt32(0))
+                            .append("provenance", new BsonString("clientSupplied"))));
+        } catch (Exception ex) {
+            fail(format("Incorrect exception thrown in test: %s" + ex.getClass()));
+        } finally {
+            disableFailPoint();
+        }
+    }
+
+    private void insertOneDocument() {
+        FutureResultCallback<InsertOneResult> callback = new FutureResultCallback<>();
+        collection.insertOne(Document.parse("{ x: 1 }"), callback);
+        futureResult(callback);
+    }
+
+    private void setFailPoint() {
+        failPointDocument = new BsonDocument("configureFailPoint", new BsonString("failCommand"))
+                .append("mode", new BsonDocument("times", new BsonInt32(1)))
+                .append("data", new BsonDocument("failCommands", new BsonArray(asList(new BsonString("insert"))))
+                        .append("writeConcernError", new BsonDocument("code", new BsonInt32(100))
+                                .append("codeName", new BsonString("UnsatisfiableWriteConcern"))
+                                .append("errmsg", new BsonString("Not enough data-bearing nodes"))
+                                .append("errInfo", new BsonDocument("writeConcern", new BsonDocument("w", new BsonInt32(2))
+                                        .append("wtimeout", new BsonInt32(0))
+                                        .append("provenance", new BsonString("clientSupplied"))))));
+        collectionHelper.runAdminCommand(failPointDocument);
+    }
+
+    private void disableFailPoint() {
+        collectionHelper.runAdminCommand(failPointDocument.append("mode", new BsonString("off")));
+    }
+
+    private boolean canRunTests() {
+        return isDiscoverableReplicaSet() && serverVersionAtLeast(4, 0);
+    }
+
+    private <T> T futureResult(final FutureResultCallback<T> callback) {
+        try {
+            return callback.get(30, TimeUnit.SECONDS);
+        } catch (Throwable t) {
+            throw MongoException.fromThrowable(t);
+        }
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/WriteConcernProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WriteConcernProseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.MongoWriteConcernException;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+// See https://github.com/mongodb/specifications/tree/master/source/change-streams/tests/README.rst#prose-tests
+public class WriteConcernProseTest extends DatabaseTestCase {
+    private BsonDocument failPointDocument;
+
+    @Before
+    @Override
+    public void setUp() {
+        assumeTrue(canRunTests());
+        super.setUp();
+    }
+
+    // Ensure that the WriteConcernError errInfo object is propagated.
+    @Test
+    public void testWriteConcernErrInfoIsPropagated() {
+        try {
+            setFailPoint();
+            collection.insertOne(Document.parse("{ x: 1 }"));
+        } catch (MongoWriteConcernException e) {
+            assertEquals(e.getWriteConcernError().getCode(), 100);
+            assertTrue(e.getWriteConcernError().getCodeName().equals("UnsatisfiableWriteConcern"));
+            assertEquals(e.getWriteConcernError().getDetails(), new BsonDocument("writeConcern",
+                    new BsonDocument("w", new BsonInt32(2))
+                            .append("wtimeout", new BsonInt32(0))
+                            .append("provenance", new BsonString("clientSupplied"))));
+        } catch (Exception ex) {
+            fail(format("Incorrect exception thrown in test: %s" + ex.getClass()));
+        } finally {
+            disableFailPoint();
+        }
+    }
+
+    private void setFailPoint() {
+        failPointDocument = new BsonDocument("configureFailPoint", new BsonString("failCommand"))
+                .append("mode", new BsonDocument("times", new BsonInt32(1)))
+                .append("data", new BsonDocument("failCommands", new BsonArray(asList(new BsonString("insert"))))
+                        .append("writeConcernError", new BsonDocument("code", new BsonInt32(100))
+                                .append("codeName", new BsonString("UnsatisfiableWriteConcern"))
+                                .append("errmsg", new BsonString("Not enough data-bearing nodes"))
+                                .append("errInfo", new BsonDocument("writeConcern", new BsonDocument("w", new BsonInt32(2))
+                                        .append("wtimeout", new BsonInt32(0))
+                                        .append("provenance", new BsonString("clientSupplied"))))));
+        getCollectionHelper().runAdminCommand(failPointDocument);
+    }
+
+    private void disableFailPoint() {
+        getCollectionHelper().runAdminCommand(failPointDocument.append("mode", new BsonString("off")));
+    }
+
+    private boolean canRunTests() {
+        return isDiscoverableReplicaSet() && serverVersionAtLeast(4, 0);
+    }
+}


### PR DESCRIPTION
JAVA-3664
Evergreen patch: https://evergreen.mongodb.com/version/5e8c2c559ccd4e7d6e7a8486