### PR TITLE
OCSP test should only run when OCSP system property is set

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/OcspTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/OcspTest.java
@@ -1,16 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.client;
 
-import com.mongodb.MongoException;
 import com.mongodb.MongoTimeoutException;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
+import org.junit.Before;
 import org.junit.Test;
 
 import static com.mongodb.ClusterFixture.getOcspShouldSucceed;
-
+import static java.security.Security.getProperty;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 public class OcspTest {
+    @Before
+    public void setUp() {
+        assumeTrue(canRunTests());
+    }
+
     @Test
     public void testTLS() {
         String uri = "mongodb://localhost/?serverSelectionTimeoutMS=2000&tls=true";
@@ -21,5 +43,9 @@ public class OcspTest {
                 fail("Unexpected exception when using OCSP with tls=true: " + e);
             }
         }
+    }
+
+    private boolean canRunTests() {
+        return getProperty("ocsp.enable") != null && getProperty("ocsp.enable").equals("true");
     }
 }


### PR DESCRIPTION
JAVA-3598
Evergreen patch: https://evergreen.mongodb.com/version/5eacacbec9ec4415c4fc628f

In my haste to close the OCSP ticket, I neglected to run an extensive set of tests (both locally and on Evergreen) which would have shown problems with the `OcspTest` file. I have fixed the issues with the test to get the tests green.