### PR TITLE
Support Keep alive probes in Java 11+

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -19,24 +19,38 @@ package com.mongodb.internal.connection;
 import com.mongodb.MongoInternalException;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
+import jdk.net.ExtendedSocketOptions;
 
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketOption;
+import java.util.Arrays;
 
 import static com.mongodb.internal.connection.SslHelper.enableHostNameVerification;
 import static com.mongodb.internal.connection.SslHelper.enableSni;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class SocketStreamHelper {
+    // Keep alive options and their values for Java 11+
+    private static final String TCP_KEEPIDLE = "TCP_KEEPIDLE";
+    private static final int TCP_KEEPIDLE_DURATION = 300;
+    private static final String TCP_KEEPCOUNT = "TCP_KEEPCOUNT";
+    private static final int TCP_KEEPCOUNT_LIMIT = 9;
+    private static final String TCP_KEEPINTERVAL = "TCP_KEEPINTERVAL";
+    private static final int TCP_KEEPINTERVAL_DURATION = 10;
 
     static void initialize(final Socket socket, final InetSocketAddress inetSocketAddress, final SocketSettings settings,
                            final SslSettings sslSettings) throws IOException {
         socket.setTcpNoDelay(true);
         socket.setSoTimeout(settings.getReadTimeout(MILLISECONDS));
         socket.setKeepAlive(true);
+
+        // Adding keep alive options for users of Java 11+. These options will be ignored for older Java versions.
+        setExtendedSocketOptions(socket);
+
         if (settings.getReceiveBufferSize() > 0) {
             socket.setReceiveBufferSize(settings.getReceiveBufferSize());
         }
@@ -61,6 +75,21 @@ final class SocketStreamHelper {
             sslSocket.setSSLParameters(sslParameters);
         }
         socket.connect(inetSocketAddress, settings.getConnectTimeout(MILLISECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setExtendedSocketOptions(final Socket socket) {
+        if (Arrays.stream(ExtendedSocketOptions.class.getDeclaredFields()).anyMatch(f -> f.getName().equals(TCP_KEEPCOUNT))) {
+            try {
+                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPCOUNT).get(null),
+                        TCP_KEEPCOUNT_LIMIT);
+                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPIDLE).get(null),
+                        TCP_KEEPIDLE_DURATION);
+                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPINTERVAL).get(null),
+                        TCP_KEEPINTERVAL_DURATION);
+            } catch (Throwable t) {
+            }
+        }
     }
 
     private SocketStreamHelper() {

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -85,9 +85,9 @@ final class SocketStreamHelper {
                 Method setOptionMethod = Socket.class.getMethod("setOption", SocketOption.class, Object.class);
                 setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
                         TCP_KEEPCOUNT_LIMIT);
-                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
+                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPIDLE).get(null),
                         TCP_KEEPIDLE_DURATION);
-                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
+                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPINTERVAL).get(null),
                         TCP_KEEPINTERVAL_DURATION);
             } catch (Throwable t) {
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -24,6 +24,7 @@ import jdk.net.ExtendedSocketOptions;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketOption;
@@ -81,11 +82,12 @@ final class SocketStreamHelper {
     private static void setExtendedSocketOptions(final Socket socket) {
         if (Arrays.stream(ExtendedSocketOptions.class.getDeclaredFields()).anyMatch(f -> f.getName().equals(TCP_KEEPCOUNT))) {
             try {
-                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPCOUNT).get(null),
+                Method setOptionMethod = Socket.class.getMethod("setOption", SocketOption.class, Object.class);
+                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
                         TCP_KEEPCOUNT_LIMIT);
-                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPIDLE).get(null),
+                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
                         TCP_KEEPIDLE_DURATION);
-                socket.setOption((SocketOption<Integer>) ExtendedSocketOptions.class.getField(TCP_KEEPINTERVAL).get(null),
+                setOptionMethod.invoke(socket, ExtendedSocketOptions.class.getDeclaredField(TCP_KEEPCOUNT).get(null),
                         TCP_KEEPINTERVAL_DURATION);
             } catch (Throwable t) {
             }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
@@ -28,6 +28,7 @@ import javax.net.SocketFactory
 import javax.net.ssl.SNIHostName
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
+import java.lang.reflect.Method
 
 import static com.mongodb.ClusterFixture.getPrimary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -52,9 +53,10 @@ class SocketStreamHelperSpecification extends Specification {
 
         // If the Java 11+ extended socket options for keep alive probes are available, check those values.
         if (Arrays.stream(ExtendedSocketOptions.getDeclaredFields()).anyMatch{ f -> f.getName().equals('TCP_KEEPCOUNT') }) {
-            socket.getOption((SocketOption<Integer>) ExtendedSocketOptions.getField('TCP_KEEPCOUNT').get(null)) == 9
-            socket.getOption((SocketOption<Integer>) ExtendedSocketOptions.getField('TCP_KEEPIDLE').get(null)) == 300
-            socket.getOption((SocketOption<Integer>) ExtendedSocketOptions.getField('TCP_KEEPINTERVAL').get(null)) == 10
+            Method getOptionMethod = Socket.getMethod('getOption', SocketOption);
+            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPCOUNT').get(null)) == 9
+            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPIDLE').get(null)) == 300
+            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPINTERVAL').get(null)) == 10
         }
 
         cleanup:


### PR DESCRIPTION
JAVA-3656
Evergreen patch: https://evergreen.mongodb.com/version/5eb320f2e3c33111187ce62b

This is an attempt to pull in Java 11 features without breaking older environments.