### PR TITLE
Use type String for _id field in POJO codec

### DIFF
--- a/bson/src/main/org/bson/codecs/StringCodec.java
+++ b/bson/src/main/org/bson/codecs/StringCodec.java
@@ -33,7 +33,9 @@ public class StringCodec implements Codec<String> {
 
     @Override
     public String decode(final BsonReader reader, final DecoderContext decoderContext) {
-        if (reader.getCurrentBsonType() == BsonType.SYMBOL) {
+        if (reader.getCurrentBsonType() == BsonType.OBJECT_ID) {
+            return reader.readObjectId().toHexString();
+        } else if (reader.getCurrentBsonType() == BsonType.SYMBOL) {
             return reader.readSymbol();
         } else {
             return reader.readString();

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/ObjectIdStringModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/ObjectIdStringModel.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+//CHECKSTYLE:OFF
+public final class ObjectIdStringModel {
+    public String _id;
+    public int id;
+    public String name;
+
+    public ObjectIdStringModel() {
+    }
+
+    public ObjectIdStringModel(final String objectId, final int id, final String name) {
+        this._id = objectId;
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -18,6 +18,7 @@ package com.mongodb.client;
 
 import com.mongodb.DBRef;
 import com.mongodb.Function;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.result.InsertManyResult;
@@ -29,6 +30,8 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.codecs.DocumentCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.entities.ObjectIdStringModel;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
@@ -40,6 +43,7 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -207,5 +211,22 @@ public class MongoCollectionTest extends DatabaseTestCase {
 
         // then
         assertEquals(doc, collection.find().first());
+    }
+
+    @Test
+    public void testObjectIdToStringConversion() {
+        // given
+        CodecRegistry pojoCodecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().automatic(true).build()));
+
+        MongoCollection<ObjectIdStringModel> test = database.getCollection("test", ObjectIdStringModel.class)
+                .withCodecRegistry(pojoCodecRegistry);
+        test.drop();
+
+        // when
+        test.insertOne(new ObjectIdStringModel(null, 1, "123"));
+
+        // then
+        assertNotNull(test.find().first()._id);
     }
 }


### PR DESCRIPTION
JAVA-3677
Evergreen patch: https://evergreen.mongodb.com/version/5eb44508a4cf470196e34f79