### PR TITLE
Test that readPreferenceTags are always interpreted as an array

### DIFF
--- a/driver-core/src/test/resources/uri-options/read-preference-options.json
+++ b/driver-core/src/test/resources/uri-options/read-preference-options.json
@@ -22,6 +22,21 @@
       }
     },
     {
+      "description": "Single readPreferenceTags is parsed as array of size one",
+      "uri": "mongodb://example.com/?readPreference=secondary&readPreferenceTags=dc:ny",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readPreferenceTags": [
+          {
+            "dc": "ny"
+          }
+        ]
+      }
+    },
+    {
       "description": "Invalid readPreferenceTags causes a warning",
       "uri": "mongodb://example.com/?readPreferenceTags=invalid",
       "valid": true,


### PR DESCRIPTION
JAVA-3681
Evergreen patch: https://evergreen.mongodb.com/version/5eb4ec001e2d174e3bb1f9e4