### PR TITLE
Add tests for allowed cases when authSource is given but username is not

### DIFF
--- a/driver-core/src/test/resources/auth/connection-string.json
+++ b/driver-core/src/test/resources/auth/connection-string.json
@@ -217,6 +217,18 @@
       }
     },
     {
+      "description": "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
+      }
+    },
+    {
       "description": "should throw an exception if supplied a password (MONGODB-X509)",
       "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-X509",
       "valid": false
@@ -362,7 +374,7 @@
       "credential": null
     },
     {
-      "description": "authSource without username doesn't create credential",
+      "description": "authSource without username doesn't create credential (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
       "valid": true,
       "credential": null
@@ -380,6 +392,18 @@
     {
       "description": "should recognise the mechanism (MONGODB-AWS)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external",
       "valid": true,
       "credential": {
         "username": null,


### PR DESCRIPTION
JAVA-3698
Evergreen patch: https://evergreen.mongodb.com/version/5eb4efe13066150804ea7e51