### PR TITLE
Avoid calling batch cursor when the cursor is closed

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
@@ -61,8 +61,6 @@ class ClientSessionHelper {
                 && clusterDescription.getLogicalSessionTimeoutMinutes() != null
                 && clusterDescription.getType() != ClusterType.STANDALONE) {
             callback.onResult(createClientSession(options, executor), null);
-        } else if (mongoClient.getCluster().isClosed()) {
-            callback.onResult(null, new IllegalStateException("createClientSession called after the cluster was closed"));
         } else {
             mongoClient.getCluster().selectServerAsync(new ServerSelector() {
                 @Override

--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.async.client;
 
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.MongoException;
 import com.mongodb.TransactionOptions;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterDescription;
@@ -62,7 +63,7 @@ class ClientSessionHelper {
                 && clusterDescription.getType() != ClusterType.STANDALONE) {
             callback.onResult(createClientSession(options, executor), null);
         } else if (mongoClient.getCluster().isClosed()) {
-            callback.onResult(null, null);
+            callback.onResult(null, new MongoException("createClientSession called after the cluster was closed"));
         } else {
             mongoClient.getCluster().selectServerAsync(new ServerSelector() {
                 @Override

--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
@@ -61,6 +61,8 @@ class ClientSessionHelper {
                 && clusterDescription.getLogicalSessionTimeoutMinutes() != null
                 && clusterDescription.getType() != ClusterType.STANDALONE) {
             callback.onResult(createClientSession(options, executor), null);
+        } else if (mongoClient.getCluster().isClosed()) {
+            callback.onResult(null, null);
         } else {
             mongoClient.getCluster().selectServerAsync(new ServerSelector() {
                 @Override

--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionHelper.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.async.client;
 
 import com.mongodb.ClientSessionOptions;
-import com.mongodb.MongoException;
 import com.mongodb.TransactionOptions;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterDescription;
@@ -63,7 +62,7 @@ class ClientSessionHelper {
                 && clusterDescription.getType() != ClusterType.STANDALONE) {
             callback.onResult(createClientSession(options, executor), null);
         } else if (mongoClient.getCluster().isClosed()) {
-            callback.onResult(null, new MongoException("createClientSession called after the cluster was closed"));
+            callback.onResult(null, new IllegalStateException("createClientSession called after the cluster was closed"));
         } else {
             mongoClient.getCluster().selectServerAsync(new ServerSelector() {
                 @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AbstractSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AbstractSubscription.java
@@ -73,6 +73,9 @@ abstract class AbstractSubscription<TResult> implements Subscription {
     @Override
     public void request(final long n) {
 
+        if (isTerminated()) {
+            return;
+        }
         if (!isUnsubscribed() && n < 1) {
             onError(new IllegalArgumentException("3.9 While the Subscription is not cancelled, "
                     + "Subscription.request(long n) MUST throw a java.lang.IllegalArgumentException if the "

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AbstractSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AbstractSubscription.java
@@ -142,7 +142,7 @@ abstract class AbstractSubscription<TResult> implements Subscription {
                 throw MongoException.fromThrowableNonNull(t1);
             }
         } else {
-            throw MongoException.fromThrowableNonNull(t);
+            throw new MongoException("Subscription has already been terminated", t);
         }
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
@@ -74,13 +74,13 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
     void requestMoreData() {
         boolean mustRead = false;
         synchronized (this) {
-            if (!isReading && !isTerminated() && batchCursor != null) {
+            if (!isReading && !isTerminated() && batchCursor != null && !batchCursor.isClosed()) {
                 isReading = true;
                 mustRead = true;
             }
         }
 
-        if (mustRead && !batchCursor.isClosed()) {
+        if (mustRead) {
             batchCursor.setBatchSize(calculateBatchSize());
             batchCursor.next((result, t) -> {
                 synchronized (MongoIterableSubscription.this) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
@@ -80,7 +80,11 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
             }
         }
 
-        if (mustRead && !batchCursor.isClosed()) {
+        if (batchCursor != null && batchCursor.isClosed()) {
+            onError(new MongoException("requestMoreData called after the batch cursor was closed"));
+        }
+
+        if (mustRead) {
             batchCursor.setBatchSize(calculateBatchSize());
             batchCursor.next((result, t) -> {
                 synchronized (MongoIterableSubscription.this) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
@@ -81,6 +81,9 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
         }
 
         if (mustRead) {
+            if (batchCursor.isClosed()) {
+                return;
+            }
             batchCursor.setBatchSize(calculateBatchSize());
             batchCursor.next((result, t) -> {
                 synchronized (MongoIterableSubscription.this) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
@@ -80,11 +80,7 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
             }
         }
 
-        if (batchCursor != null && batchCursor.isClosed()) {
-            onError(new MongoException("requestMoreData called after the batch cursor was closed"));
-        }
-
-        if (mustRead) {
+        if (mustRead && !batchCursor.isClosed()) {
             batchCursor.setBatchSize(calculateBatchSize());
             batchCursor.next((result, t) -> {
                 synchronized (MongoIterableSubscription.this) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoIterableSubscription.java
@@ -80,10 +80,7 @@ final class MongoIterableSubscription<TResult> extends AbstractSubscription<TRes
             }
         }
 
-        if (mustRead) {
-            if (batchCursor.isClosed()) {
-                return;
-            }
+        if (mustRead && !batchCursor.isClosed()) {
             batchCursor.setBatchSize(calculateBatchSize());
             batchCursor.next((result, t) -> {
                 synchronized (MongoIterableSubscription.this) {

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FlatteningSingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FlatteningSingleResultCallbackSubscriptionSpecification.groovy
@@ -265,7 +265,8 @@ class FlatteningSingleResultCallbackSubscriptionSpecification extends Specificat
 
         then:
         def ex = thrown(MongoException)
-        ex.message == 'exception calling onComplete'
+        ex.message == 'Subscription has already been terminated'
+        ex.cause.cause.message == 'exception calling onComplete'
         subscriber.assertTerminalEvent()
         subscriber.assertNoErrors()
     }
@@ -298,7 +299,8 @@ class FlatteningSingleResultCallbackSubscriptionSpecification extends Specificat
 
         then:
         def ex = thrown(MongoException)
-        ex.message == 'exception calling onError'
+        ex.message == 'Subscription has already been terminated'
+        ex.cause.cause.message == 'exception calling onError'
         subscriber.assertTerminalEvent()
         subscriber.assertErrored()
     }

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/SingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/SingleResultCallbackSubscriptionSpecification.groovy
@@ -302,7 +302,8 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
         def ex = thrown(MongoException)
         subscriber.assertNoErrors()
         subscriber.assertTerminalEvent()
-        ex.message == 'exception calling onComplete'
+        ex.message == 'Subscription has already been terminated'
+        ex.cause.cause.message == 'exception calling onComplete'
     }
 
     def 'should throw the exception if calling onError raises one'() {


### PR DESCRIPTION
JAVA-3710
https://jira.mongodb.org/browse/JAVA-3710
If a cursor is closed when requesting data, do not continue.