### PR TITLE
Reduce default keepalive time to align with Azure defaults

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 final class SocketStreamHelper {
     // Keep alive options and their values for Java 11+
     private static final String TCP_KEEPIDLE = "TCP_KEEPIDLE";
-    private static final int TCP_KEEPIDLE_DURATION = 300;
+    private static final int TCP_KEEPIDLE_DURATION = 120;
     private static final String TCP_KEEPCOUNT = "TCP_KEEPCOUNT";
     private static final int TCP_KEEPCOUNT_LIMIT = 9;
     private static final String TCP_KEEPINTERVAL = "TCP_KEEPINTERVAL";

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
@@ -55,7 +55,7 @@ class SocketStreamHelperSpecification extends Specification {
         if (Arrays.stream(ExtendedSocketOptions.getDeclaredFields()).anyMatch{ f -> f.getName().equals('TCP_KEEPCOUNT') }) {
             Method getOptionMethod = Socket.getMethod('getOption', SocketOption);
             getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPCOUNT').get(null)) == 9
-            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPIDLE').get(null)) == 300
+            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPIDLE').get(null)) == 120
             getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPINTERVAL').get(null)) == 10
         }
 


### PR DESCRIPTION
JAVA-3743

This sets the keepalive time to 120 seconds to resolve the problem of Azure silently dropping connections after 240 seconds.
Evergreen patch: https://evergreen.mongodb.com/version/5ed54a8ad6d80a498510ccf4