### PR TITLE
Add coverage for valid maxStalenessSeconds with no viable servers

### DIFF
--- a/driver-core/src/main/com/mongodb/TaggableReadPreference.java
+++ b/driver-core/src/main/com/mongodb/TaggableReadPreference.java
@@ -255,10 +255,12 @@ public abstract class TaggableReadPreference extends ReadPreference {
             }
         } else {
             ServerDescription mostUpToDateSecondary = findMostUpToDateSecondary(clusterDescription);
-            for (ServerDescription cur : servers) {
-                if (getLastWriteDateNonNull(mostUpToDateSecondary).getTime() - getLastWriteDateNonNull(cur).getTime()
-                        + heartbeatFrequencyMS <= maxStaleness) {
-                    freshServers.add(cur);
+            if (mostUpToDateSecondary != null) {
+                for (ServerDescription cur : servers) {
+                    if (getLastWriteDateNonNull(mostUpToDateSecondary).getTime() - getLastWriteDateNonNull(cur).getTime()
+                            + heartbeatFrequencyMS <= maxStaleness) {
+                        freshServers.add(cur);
+                    }
                 }
             }
         }
@@ -292,9 +294,6 @@ public abstract class TaggableReadPreference extends ReadPreference {
                     mostUpdateToDateSecondary = cur;
                 }
             }
-        }
-        if (mostUpdateToDateSecondary == null) {
-            throw new MongoInternalException("Expected at least one secondary in cluster description: " + clusterDescription);
         }
         return mostUpdateToDateSecondary;
     }

--- a/driver-core/src/test/resources/max-staleness/server_selection/ReplicaSetNoPrimary/MaxStalenessTooSmall.json
+++ b/driver-core/src/test/resources/max-staleness/server_selection/ReplicaSetNoPrimary/MaxStalenessTooSmall.json
@@ -14,8 +14,7 @@
   },
   "read_preference": {
     "mode": "Nearest",
-    "maxStalenessSeconds": 90
+    "maxStalenessSeconds": 1
   },
-  "suitable_servers": [],
-  "in_latency_window": []
+  "error": true
 }

--- a/driver-core/src/test/resources/max-staleness/server_selection/Unknown/SmallMaxStaleness.json
+++ b/driver-core/src/test/resources/max-staleness/server_selection/Unknown/SmallMaxStaleness.json
@@ -5,7 +5,8 @@
     "servers": [
       {
         "address": "a:27017",
-        "type": "Unknown"
+        "type": "Unknown",
+        "maxWireVersion": 5
       }
     ]
   },


### PR DESCRIPTION
JAVA-3760
Evergreen patch: https://evergreen.mongodb.com/version/5efea2e82a60ed028ed1667d